### PR TITLE
Port Claude Code workflows to Codex skills

### DIFF
--- a/.agents/skills/cgs-architecture-decision/SKILL.md
+++ b/.agents/skills/cgs-architecture-decision/SKILL.md
@@ -1,0 +1,101 @@
+---
+name: cgs-architecture-decision
+description: Use to create or retrofit an Architecture Decision Record for Codex Game Studios, including status, context, decision, consequences, dependencies, engine compatibility, and GDD requirement traceability. This is the Codex-native replacement for the original Claude Code `/architecture-decision` workflow.
+metadata:
+  short-description: Create or retrofit an ADR
+---
+
+# Codex Game Studios Architecture Decision
+
+This skill creates or retrofits ADRs in `docs/architecture/`.
+
+## Modes
+
+- New ADR: user provides a technical decision title or problem.
+- Guided ADR: user asks what ADR is needed next.
+- Retrofit: user provides an existing ADR path and wants missing sections added
+  without overwriting existing content.
+
+## Inputs To Read
+
+- `.claude/docs/technical-preferences.md`.
+- Relevant engine reference docs under `docs/engine-reference/<engine>/`.
+- `docs/architecture/architecture.md`, if present.
+- Existing `docs/architecture/adr-*.md`.
+- `docs/registry/architecture.yaml`, if present.
+- Relevant GDDs under `design/gdd/`.
+- `docs/architecture/tr-registry.yaml`, if present.
+- `.claude/docs/templates/architecture-decision-record.md`.
+- Original source workflow, only if more detail is needed:
+  `.claude/skills/architecture-decision/SKILL.md`.
+
+If no engine is configured, ask whether to configure the engine first or proceed
+with an explicitly engine-agnostic ADR.
+
+## New ADR Workflow
+
+1. Determine next ADR number from existing `adr-*.md` files.
+2. Identify decision domain: Core, Physics, Rendering, UI, Audio, Navigation,
+   Animation, Networking, Input, Scripting, Persistence, Build, or Tools.
+3. Read relevant GDD and architecture context.
+4. Read engine reference docs for the domain and flag deprecated/post-cutoff
+   APIs.
+5. Present assumptions before drafting:
+   - Problem.
+   - Alternatives.
+   - Recommended decision.
+   - Dependencies.
+   - GDD requirements addressed.
+   - Engine risk.
+
+Ask the user to confirm or adjust assumptions before writing.
+
+## Required ADR Sections
+
+- Status: Proposed by default unless the user explicitly chooses Accepted.
+- Date.
+- Context.
+- Decision Drivers.
+- Options Considered.
+- Decision.
+- Consequences.
+- ADR Dependencies.
+- Engine Compatibility.
+- GDD Requirements Addressed.
+- Verification Plan.
+
+## Retrofit Workflow
+
+For an existing ADR:
+
+- Detect missing sections.
+- Report existing sections that will not be touched.
+- Ask before appending missing sections.
+- Never overwrite existing authored sections.
+- Add `Status`, `ADR Dependencies`, `Engine Compatibility`, and
+  `GDD Requirements Addressed` first because stories depend on them.
+
+## Write Output
+
+Before editing, show the target path and summary. After approval, write:
+
+`docs/architecture/adr-[NNNN]-[slug].md`
+
+For status:
+
+- `Proposed`: safe for discussion, blocks implementation stories.
+- `Accepted`: implementation-ready.
+- `Superseded`: must name replacement ADR.
+- `Deprecated`: retained for history, not new work.
+
+## Completion
+
+Finish with:
+
+- ADR path.
+- Status.
+- Dependencies.
+- GDD/TR IDs addressed.
+- Engine risks and verification items.
+- Next recommended Codex request: architecture review, control manifest, or epic
+  creation.

--- a/.agents/skills/cgs-architecture-review/SKILL.md
+++ b/.agents/skills/cgs-architecture-review/SKILL.md
@@ -1,0 +1,71 @@
+---
+name: cgs-architecture-review
+description: Use to review Codex Game Studios architecture for GDD requirement coverage, ADR consistency, engine compatibility, and traceability gaps. This is the Codex-native replacement for the original Claude Code `/architecture-review` workflow.
+metadata:
+  short-description: Review architecture coverage
+---
+
+# Codex Game Studios Architecture Review
+
+This skill validates that architecture and ADRs cover the game's design
+requirements and target the pinned engine safely.
+
+## Modes
+
+- Full review: coverage, consistency, and engine checks.
+- Coverage: GDD requirements to ADR coverage.
+- Consistency: cross-ADR conflicts and dependency cycles.
+- Engine: engine version, deprecated APIs, and compatibility risks.
+- RTM: requirement to ADR to story to test traceability.
+
+## Inputs To Read
+
+- `design/gdd/*.md` and `design/gdd/systems-index.md`.
+- `docs/architecture/architecture.md`.
+- `docs/architecture/adr-*.md`.
+- `docs/architecture/tr-registry.yaml`, if present.
+- `.claude/docs/technical-preferences.md`.
+- `docs/engine-reference/<engine>/VERSION.md`, `deprecated-apis.md`,
+  `breaking-changes.md`, and relevant module docs.
+- Stories under `production/epics/**/*.md` and tests under `tests/` for RTM mode.
+- Original source workflow, only if more detail is needed:
+  `.claude/skills/architecture-review/SKILL.md`.
+
+## Checks
+
+- Extract technical requirements from GDDs.
+- Reuse stable TR IDs from `tr-registry.yaml`; never renumber existing IDs.
+- Map each requirement to ADR coverage: Covered, Partial, or Gap.
+- Detect ADR conflicts: ownership, integration contracts, performance budgets,
+  dependency cycles, state authority, and incompatible patterns.
+- Verify all ADRs have Status, ADR Dependencies, Engine Compatibility, and GDD
+  Requirements Addressed sections.
+- Verify ADR engine versions match the configured engine.
+- Flag deprecated or unverified post-cutoff APIs.
+
+## Output
+
+Use verdicts:
+
+- `PASS`: coverage is complete or gaps are low-risk and documented.
+- `CONCERNS`: meaningful gaps or risks exist, but work can continue if accepted.
+- `FAIL`: missing architecture, blocking ADR gaps, dependency cycles, or unsafe
+  engine assumptions.
+
+Report:
+
+- Requirement coverage counts.
+- Gap list with recommended ADRs.
+- ADR conflicts and cycles.
+- Engine compatibility risks.
+- RTM coverage if requested.
+
+## Optional Writes
+
+Only after user approval:
+
+- Update `docs/architecture/tr-registry.yaml`.
+- Write `docs/architecture/architecture-review-[date].md`.
+- Write `docs/architecture/requirements-traceability.md` in RTM mode.
+
+Do not edit ADR decisions during review; recommend follow-up ADR work instead.

--- a/.agents/skills/cgs-art-bible/SKILL.md
+++ b/.agents/skills/cgs-art-bible/SKILL.md
@@ -1,0 +1,84 @@
+---
+name: cgs-art-bible
+description: Use to author or retrofit a Codex Game Studios art bible from an approved game concept, defining visual identity, mood, shape language, color system, production art direction, asset standards, references, and sign-off status. This is the Codex-native replacement for the original Claude Code `/art-bible` workflow.
+metadata:
+  short-description: Author an art bible
+---
+
+# Codex Game Studios Art Bible
+
+This skill creates `design/art/art-bible.md`, the visual identity constraint
+document that guides asset production.
+
+## Preconditions
+
+Read `design/gdd/game-concept.md`. If missing, stop and recommend
+`cgs-brainstorm` first.
+
+Extract:
+
+- title.
+- core fantasy and elevator pitch.
+- game pillars.
+- visual identity anchor, if present.
+- target platform.
+
+Read `.claude/docs/technical-preferences.md` for engine and performance
+constraints when available.
+
+## Retrofit Mode
+
+If `design/art/art-bible.md` exists:
+
+- read it.
+- classify each section as Complete, Empty, or Placeholder.
+- work only on incomplete sections unless the user asks to revise existing
+  content.
+
+## Scope
+
+Ask which scope to author when not obvious:
+
+- full bible.
+- visual identity core.
+- asset standards only.
+- resume missing sections.
+
+Ask for reference games, films, artists, or visual examples if none are present.
+
+## Sections
+
+Author the requested sections:
+
+- Visual Identity Statement: one-line rule plus supporting principles.
+- Mood and Atmosphere: emotional targets and lighting by game state.
+- Shape Language: character, environment, UI, hero/supporting shapes.
+- Color System: palette roles, semantic colors, UI divergence, accessibility.
+- Character Design Direction.
+- Environment Design Language.
+- UI/HUD Visual Direction.
+- Asset Standards: formats, naming, size/resolution tiers, LOD, engine
+  constraints.
+- Reference Direction: what to borrow and what to avoid.
+
+Do not assume Claude named agents exist. Use Codex delegation only when the user
+explicitly asks for parallel agent work. If no delegation is requested, draft
+from the concept, references, and constraints, then ask for approval.
+
+## Write Output
+
+Present drafted sections for approval. After approval or explicit write
+request, create `design/art/` and write or update
+`design/art/art-bible.md`.
+
+Preserve existing completed sections unless explicitly instructed to revise.
+
+## Completion
+
+Finish with:
+
+- art bible path if written.
+- sections authored or updated.
+- unresolved visual decisions.
+- next recommended Codex request: map systems, setup engine, design system,
+  asset spec, consistency check, or create architecture.

--- a/.agents/skills/cgs-asset-audit/SKILL.md
+++ b/.agents/skills/cgs-asset-audit/SKILL.md
@@ -1,0 +1,79 @@
+---
+name: cgs-asset-audit
+description: Use to run a read-only Codex Game Studios asset compliance audit across art, audio, VFX, shaders, and data files, checking naming, formats, size budgets, orphaned files, missing references, and pipeline standard violations. This is the Codex-native replacement for the original Claude Code `/asset-audit` workflow.
+metadata:
+  short-description: Audit asset compliance
+---
+
+# Codex Game Studios Asset Audit
+
+This skill is read-only. It reports asset pipeline problems without modifying
+files.
+
+## Scope
+
+Accept a category or `all`:
+
+- `art`
+- `audio`
+- `vfx`
+- `shaders`
+- `data`
+- `all`
+
+Default to `all` when unspecified.
+
+## Inputs To Read
+
+- `design/art/art-bible.md`, if present.
+- `design/assets/asset-manifest.md`, if present.
+- `design/assets/specs/*.md`, if present.
+- `.claude/docs/technical-preferences.md`.
+- Relevant asset directories:
+  - `assets/art/**/*`
+  - `assets/audio/**/*`
+  - `assets/vfx/**/*`
+  - `assets/shaders/**/*`
+  - `assets/data/**/*`
+- Source references to assets under `src/`, `design/`, and config files.
+- Original source workflow, only if more detail is needed:
+  `.claude/skills/asset-audit/SKILL.md`.
+
+## Checks
+
+Check:
+
+- naming conventions: lowercase, underscores, category-specific patterns.
+- file format compliance.
+- size, duration, resolution, and budget issues when data is available.
+- data validity for JSON/YAML-like files.
+- orphaned assets with no references.
+- missing assets referenced by code or docs.
+- spec/manifest drift.
+
+If dimensions, duration, or metadata cannot be read with available tools, report
+the check as inconclusive rather than guessing.
+
+## Report
+
+Generate:
+
+- Summary: scanned count, naming violations, size violations, format
+  violations, orphaned assets, missing assets, overall health.
+- Naming Violations table.
+- Size or Budget Violations table.
+- Format Violations table.
+- Orphaned Assets table.
+- Missing Assets table.
+- Spec/Manifest Drift.
+- Recommendations.
+- Verdict: `COMPLIANT`, `WARNINGS`, or `NON-COMPLIANT`.
+
+## Completion
+
+Finish with:
+
+- audit verdict.
+- top blockers.
+- highest-value cleanup actions.
+- next recommended Codex request: content audit, asset spec, or targeted fixes.

--- a/.agents/skills/cgs-asset-spec/SKILL.md
+++ b/.agents/skills/cgs-asset-spec/SKILL.md
@@ -1,0 +1,92 @@
+---
+name: cgs-asset-spec
+description: Use to generate Codex Game Studios per-asset visual specifications and AI generation prompts from an art bible plus system, level, or character source documents, updating asset spec files and the master asset manifest after approval. This is the Codex-native replacement for the original Claude Code `/asset-spec` workflow.
+metadata:
+  short-description: Generate asset specs
+---
+
+# Codex Game Studios Asset Spec
+
+This skill turns approved design context into producible asset specifications.
+
+## Target
+
+Accept:
+
+- `system:[name]`
+- `level:[name]`
+- `character:[name]`
+
+If no target is provided, check `design/assets/asset-manifest.md` for the first
+Needed asset context without specs. If no manifest exists, ask for a target.
+
+Review modes:
+
+- `full`: include art and technical constraint passes.
+- `lean`: art direction only.
+- `solo`: derive from existing docs without delegation.
+
+Use Codex delegation only when the user explicitly asks for parallel agent work.
+
+## Required Inputs
+
+- `design/art/art-bible.md`; stop if missing.
+- `.claude/docs/technical-preferences.md`.
+- Source doc:
+  - system: `design/gdd/[target].md`
+  - level: `design/levels/[target].md`
+  - character: `design/narrative/characters/[target].md` or matching narrative
+    file.
+- Existing `design/assets/asset-manifest.md`, if present.
+- Existing `design/assets/specs/*.md`, to avoid duplicate shared assets.
+- Original source workflow, only if more detail is needed:
+  `.claude/skills/asset-spec/SKILL.md`.
+
+## Identify Assets
+
+Extract explicit and implied assets:
+
+- sprites and 2D art.
+- VFX and particles.
+- environment props, tiles, backgrounds, skyboxes.
+- UI elements and custom fonts.
+- audio SFX, music, ambient loops.
+- 3D meshes, materials, textures.
+
+Present the grouped asset list and confirm before writing specs.
+
+## Generate Specs
+
+For each asset, produce:
+
+- stable `ASSET-NNN` ID, continuing from the manifest.
+- category.
+- dimensions, polycount, texture resolution, file format, and naming.
+- visual or audio description.
+- art bible anchors by section.
+- generation prompt for visual assets, or sonic brief for audio.
+- status: Needed.
+
+Surface conflicts between desired art direction and technical constraints; do
+not silently resolve them.
+
+## Write Output
+
+After approval or explicit write request:
+
+- create `design/assets/specs/`.
+- write `design/assets/specs/[target-name]-assets.md`.
+- create or update `design/assets/asset-manifest.md`.
+
+Ask separately before updating the manifest if the user did not explicitly
+request both files.
+
+## Completion
+
+Finish with:
+
+- spec path if written.
+- manifest update status.
+- assets specced.
+- reused/shared assets.
+- next recommended Codex request: another asset spec or asset audit.

--- a/.agents/skills/cgs-balance-check/SKILL.md
+++ b/.agents/skills/cgs-balance-check/SKILL.md
@@ -1,0 +1,93 @@
+---
+name: cgs-balance-check
+description: Use to analyze Codex Game Studios balance data, formulas, and GDD tuning targets for combat, economy, progression, loot, or a specific data file, identifying outliers, degenerate strategies, broken curves, and recommended fixes. This is the Codex-native replacement for the original Claude Code `/balance-check` workflow.
+metadata:
+  short-description: Check game balance
+---
+
+# Codex Game Studios Balance Check
+
+This skill analyzes balance data against design intent. It reports issues first;
+data changes require explicit user instruction.
+
+## Scope
+
+Accept:
+
+- system name such as combat, economy, progression, or loot.
+- path to a data or balance file.
+
+If missing, ask which balance domain to check.
+
+## Inputs To Read
+
+- Relevant files under `assets/data/`.
+- Relevant files under `design/balance/`.
+- Matching system GDD under `design/gdd/`.
+- Formulas, tuning knobs, expected ranges, and acceptance criteria.
+- Original source workflow, only if more detail is needed:
+  `.claude/skills/balance-check/SKILL.md`.
+
+## Domain Checks
+
+Combat:
+
+- DPS and time-to-kill by tier.
+- strictly dominant options.
+- defensive loops or unkillable states.
+- damage/resistance interactions.
+
+Economy:
+
+- resource faucets and sinks.
+- accumulation over time.
+- infinite loops.
+- price/value mismatches.
+
+Progression:
+
+- XP/power curves.
+- dead zones and power spikes.
+- content gates vs expected player power.
+- grind/skip strategy risk.
+
+Loot:
+
+- rarity distribution.
+- expected acquisition time.
+- pity timer math.
+- useless loot and inventory pressure.
+
+## Report
+
+Generate:
+
+- Data Sources Analyzed.
+- Health Summary: `HEALTHY`, `CONCERNS`, or `CRITICAL ISSUES`.
+- Outliers Detected table.
+- Degenerate Strategies Found.
+- Progression or flow analysis.
+- Recommendations by priority.
+- Values That Need Attention.
+
+Label weak estimates and missing source data explicitly.
+
+## Fix Cycle
+
+After presenting the report, ask before changing data. If the user asks to fix:
+
+- change the smallest relevant data file or formula.
+- explain the design impact.
+- recommend rerunning the balance check.
+- flag GDD/ADR downstream impacts when tuning knobs change.
+
+## Completion
+
+Finish with:
+
+- balance health.
+- highest priority issue.
+- files analyzed.
+- changes made, if any.
+- next recommended Codex request: rerun balance check, propagate design change,
+  sprint plan, or quick design.

--- a/.agents/skills/cgs-brainstorm/SKILL.md
+++ b/.agents/skills/cgs-brainstorm/SKILL.md
@@ -1,0 +1,111 @@
+---
+name: cgs-brainstorm
+description: Use to guide Codex Game Studios concept ideation from no idea, a vague theme, or a rough pitch into a structured game concept document. This is the Codex-native replacement for the original Claude Code `/brainstorm` workflow.
+metadata:
+  short-description: Create a game concept
+---
+
+# Codex Game Studios Brainstorm
+
+This skill turns a seed idea into `design/gdd/game-concept.md`. It is
+collaborative: Codex facilitates options and structure, but the user owns the
+creative direction.
+
+## Inputs To Read
+
+- `production/review-mode.txt`, if present.
+- `design/gdd/game-concept.md`, if resuming.
+- `design/gdd/game-pillars.md`, if present.
+- `.claude/docs/templates/game-concept.md` for the output shape.
+- Original source workflow, only if more detail is needed:
+  `.claude/skills/brainstorm/SKILL.md`.
+
+## Discovery
+
+If no concept exists, ask only the highest-signal questions needed to start:
+
+- What games, moments, or fantasies should this project capture?
+- What genres or themes are attractive or off-limits?
+- What player experience is primary: challenge, story, expression, discovery,
+  relaxation, or social play?
+- What are the realistic constraints: timeline, team size, skill level, target
+  platform, and desired scope?
+
+If the user provides a seed, use it. If not, run open ideation.
+
+## Generate Concepts
+
+Produce three distinct concepts using different angles:
+
+- Verb-first design: start from the dominant player action.
+- Mashup method: combine genre, theme, or emotion in a non-obvious way.
+- Experience-first/MDA: start from the intended emotion and work backward.
+
+For each concept, include:
+
+- Working title.
+- Elevator pitch.
+- Core verb.
+- Core fantasy.
+- Unique hook.
+- Primary MDA aesthetic.
+- Estimated scope.
+- Biggest promise.
+- Biggest risk.
+
+Ask the user to choose one, combine elements, or request fresh directions.
+
+## Build The Chosen Concept
+
+After selection, define:
+
+- 30-second loop: moment-to-moment action.
+- 5-minute loop: short-term goals and choices.
+- Session loop: 30-120 minute play structure and stopping points.
+- Long-term progression: growth, mastery, story, or unlocks.
+- Player motivation: autonomy, competence, relatedness.
+- Target audience and comparable games.
+- Visual Identity Anchor: 2-4 sentences describing the art/style direction that
+  should later feed the art bible.
+
+## Pillars
+
+Collaboratively define:
+
+- 3-5 game pillars, each with a one-sentence definition and a design test.
+- At least 3 anti-pillars that clearly block scope creep.
+
+Do not lock pillars until the user agrees they express the intended game.
+
+## Write Output
+
+Before editing, summarize the intended document and ask whether to write it.
+After approval:
+
+- Create `design/gdd/` if needed.
+- Write or update `design/gdd/game-concept.md`.
+- Preserve existing useful content if resuming; do not overwrite the user's
+  prior concept without explicit approval.
+
+Minimum document sections:
+
+- Elevator Pitch
+- Core Fantasy
+- Target Audience
+- Game Pillars
+- Anti-Pillars
+- Core Loop
+- MDA Analysis
+- Player Motivation
+- Visual Identity Anchor
+- Scope Tiers
+- Engine Recommendation, if enough context exists
+- Open Questions
+
+## Completion
+
+Finish with:
+
+- The concept path written or updated.
+- The next recommended Codex request: configure the engine, define the art
+  bible, or map systems.

--- a/.agents/skills/cgs-bug-report/SKILL.md
+++ b/.agents/skills/cgs-bug-report/SKILL.md
@@ -1,0 +1,108 @@
+---
+name: cgs-bug-report
+description: Use to create, analyze, verify, or close Codex Game Studios bug reports, including severity, priority, reproduction steps, technical context, evidence, verification status, and closure records. This is the Codex-native replacement for the original Claude Code `/bug-report` workflow.
+metadata:
+  short-description: File or verify bugs
+---
+
+# Codex Game Studios Bug Report
+
+This skill creates structured bug reports and manages verification/closure
+without skipping evidence.
+
+## Modes
+
+- `description`: create a report from a user-provided bug description.
+- `analyze [path]`: inspect target files and draft potential bug reports.
+- `verify [BUG-ID]`: check whether an existing bug fix is actually resolved.
+- `close [BUG-ID]`: close a bug only after it is verified fixed.
+
+If no description or mode is provided, ask for the observed problem before
+continuing.
+
+## Inputs To Read
+
+- Existing bug files under `production/qa/bugs/`.
+- Target source files for analyze mode.
+- Related story, GDD, QA, test, and release docs when identifiable.
+- Test files for the affected system.
+- Git commit/build context when available.
+- Original source workflow, only if more detail is needed:
+  `.claude/skills/bug-report/SKILL.md`.
+
+## Description Mode
+
+Extract or ask for:
+
+- title/summary.
+- severity and priority.
+- category and affected system.
+- frequency and regression status.
+- environment: build, platform, scene/level, game state.
+- exact reproduction steps and preconditions.
+- expected and actual result.
+- logs, screenshots, videos, or notes.
+
+Search the codebase for likely affected files and related systems, but label
+possible root causes as hypotheses unless verified.
+
+## Analyze Mode
+
+Review target files for likely bugs:
+
+- null/empty state failures.
+- off-by-one and boundary issues.
+- race conditions or bad async ordering.
+- resource leaks or missing cleanup.
+- incorrect state transitions.
+- unhandled save/load, input, platform, or network edge cases.
+
+For each credible issue, draft a bug report with trigger scenario, impact, and
+recommended fix direction.
+
+## Verify Mode
+
+Read `production/qa/bugs/[BUG-ID].md`.
+
+Check:
+
+- original reproduction path.
+- whether the suspected root-cause code path changed.
+- related tests and regression coverage.
+- adjacent occurrences of the same bug pattern.
+
+Verdicts:
+
+- `VERIFIED FIXED`
+- `STILL PRESENT`
+- `CANNOT VERIFY`
+
+Ask before updating the bug file unless the user explicitly requested the
+update.
+
+## Close Mode
+
+Only close when status is `Verified Fixed` or equivalent evidence is present.
+Append a closure record with date, resolution, fix commit/PR if known, verifier,
+closer, regression test or manual evidence, and final status.
+
+Do not close unverified bugs. Recommend `verify` first.
+
+## Write Output
+
+For new reports, present the draft first. After approval or explicit write
+request, create `production/qa/bugs/` and write
+`production/qa/bugs/BUG-[NNNN].md`.
+
+For verify/close, update the existing file only after approval or explicit
+request.
+
+## Completion
+
+Finish with:
+
+- bug path if written or updated.
+- severity/priority.
+- verification or closure status.
+- next recommended Codex request: bug triage, hotfix for S1/S2, or regression
+  suite update.

--- a/.agents/skills/cgs-bug-triage/SKILL.md
+++ b/.agents/skills/cgs-bug-triage/SKILL.md
@@ -1,0 +1,101 @@
+---
+name: cgs-bug-triage
+description: Use to triage Codex Game Studios open bugs by severity, priority, sprint assignment, trend, hot spots, regressions, age, and systemic risk, producing a prioritized bug triage report. This is the Codex-native replacement for the original Claude Code `/bug-triage` workflow.
+metadata:
+  short-description: Triage open bugs
+---
+
+# Codex Game Studios Bug Triage
+
+This skill turns the open bug backlog into a prioritized action list. It
+separates severity from priority and flags systemic risks.
+
+## Modes
+
+- `sprint`: triage against current sprint scope and capacity.
+- `full`: triage all open bugs regardless of sprint scope.
+- `trend`: trend analysis only; read-only report with no assignment changes.
+
+If mode is missing, use `sprint` when a current sprint exists; otherwise use
+`full`.
+
+## Inputs To Read
+
+- `production/qa/bugs/*.md`.
+- `production/qa/bugs.md` as fallback.
+- QA plan "Bugs Found" tables as a last resort.
+- Latest sprint plan and `production/sprint-status.yaml`, if present.
+- Previous bug triage reports.
+- Severity/priority guidance from `.claude/docs/coding-standards.md`, if
+  present.
+- Original source workflow, only if more detail is needed:
+  `.claude/skills/bug-triage/SKILL.md`.
+
+If no bug files exist, report that there is nothing to triage and stop.
+
+## Classify Bugs
+
+Severity:
+
+- `S1 Critical`: crash, data loss, complete blocker, severe security issue.
+- `S2 High`: major broken feature or significant wrong behavior.
+- `S3 Medium`: degraded feature with workaround.
+- `S4 Low`: cosmetic, typo, minor polish.
+
+Priority:
+
+- `P1`: fix this sprint; blocks QA/release or is serious regression.
+- `P2`: fix soon; needed before next major milestone.
+- `P3`: backlog.
+- `P4`: deferred or won't-fix candidate.
+
+Priority is a recommendation. Do not mark won't-fix or close bugs without user
+approval.
+
+## Assignment And Trend Rules
+
+For sprint mode:
+
+- assign P1/P2 only when sprint scope and capacity allow it.
+- flag overflow rather than silently overfilling the sprint.
+- identify target story or epic when possible.
+
+Flag systemic issues:
+
+- 3+ bugs in the same system.
+- 2+ S1/S2 bugs from the same story.
+- bugs against stories marked complete.
+- S1/S2 bugs older than two sprints or unassigned.
+
+## Report Output
+
+Generate:
+
+- Triage Summary by priority.
+- Critical S1/S2 unfixed count.
+- P1 Bugs table.
+- P2 Bugs table.
+- P3/P4 Bugs table.
+- Systemic Issues Flagged.
+- Trend Analysis: volume, hot spots, regressions, aged bugs.
+- Recommended Actions.
+
+For `trend`, omit assignment changes and focus on metrics and risk patterns.
+
+## Write Output
+
+Present the report first. After approval or explicit write request, create
+`production/qa/` and write `production/qa/bug-triage-[date].md`.
+
+Do not edit individual bug files unless explicitly requested.
+
+## Completion
+
+Finish with:
+
+- triage report path if written.
+- P1/P2 count.
+- unassigned S1/S2 count.
+- systemic risks.
+- next recommended Codex request: sprint plan, hotfix, smoke check, or
+  regression suite update.

--- a/.agents/skills/cgs-changelog/SKILL.md
+++ b/.agents/skills/cgs-changelog/SKILL.md
@@ -1,0 +1,98 @@
+---
+name: cgs-changelog
+description: Use to generate Codex Game Studios internal and player-facing changelogs from git history, sprint records, milestone docs, GDDs, and release notes, with categories, metrics, known issues, and task-reference coverage. This is the Codex-native replacement for the original Claude Code `/changelog` workflow.
+metadata:
+  short-description: Generate a changelog
+---
+
+# Codex Game Studios Changelog
+
+This skill turns development history into an internal changelog and a
+player-facing summary.
+
+## Scope
+
+Accept a version, release tag, sprint number, date range, or "latest". If scope
+is missing, infer from tags or sprint docs when obvious; otherwise ask.
+
+## Inputs To Read
+
+- Git tags and commits for the requested range.
+- Existing `docs/CHANGELOG.md`, if present.
+- Sprint plans/status/retrospectives under `production/sprints/`.
+- Release records under `production/releases/`.
+- Milestones under `production/milestones/`.
+- Relevant GDDs under `design/gdd/`.
+- QA bug and known-issue records, if present.
+- Original source workflow, only if more detail is needed:
+  `.claude/skills/changelog/SKILL.md`.
+
+## Git Handling
+
+Confirm the repository is a git worktree before using git history. If not,
+explain that changelog generation needs explicit release/sprint notes.
+
+Use:
+
+- last matching tag to `HEAD`, if a version/tag is provided.
+- previous tag to current tag, if both exist.
+- sprint date range, if a sprint number is provided.
+- a recent bounded range when no tags exist.
+
+Ignore merge/fixup noise in the public narrative, but keep useful technical
+detail in the internal changelog.
+
+## Categorize Changes
+
+Use these categories:
+
+- New Features
+- Improvements
+- Bug Fixes
+- Balance Changes
+- Technical Debt / Refactoring
+- Known Issues
+- Miscellaneous
+
+Count commits without a task reference such as `[STORY-123]`, `TR-`, `#NNN`,
+or a repository-specific ticket prefix.
+
+## Internal Changelog
+
+Include:
+
+- Version/date/sprint range.
+- Commit count and hash range.
+- Categorized changes with technical context.
+- Related story/issue/design references where available.
+- Owners only if already documented.
+- Known issues and risk notes.
+- Metrics: total commits, files changed, lines added/removed, commits without
+  task reference.
+
+## Player-Facing Changelog
+
+Translate implementation details into player impact:
+
+- avoid internal paths, ticket IDs, developer names, and jargon.
+- group related fixes instead of listing every commit.
+- explain balance changes with before/after values and player-facing intent.
+- include known issues honestly, with workarounds when available.
+
+## Output And Write
+
+Show both changelogs first. If writing is approved:
+
+- Append to the top of `docs/CHANGELOG.md` when it exists.
+- Create `docs/CHANGELOG.md` when missing.
+- Only overwrite if the user explicitly asks.
+
+## Completion
+
+Finish with:
+
+- Changelog status: generated or written.
+- File path if written.
+- Commit range.
+- Missing evidence or vague commits that need human review.
+- Next recommended Codex request: patch notes or release checklist.

--- a/.agents/skills/cgs-code-review/SKILL.md
+++ b/.agents/skills/cgs-code-review/SKILL.md
@@ -1,0 +1,58 @@
+---
+name: cgs-code-review
+description: Use to perform a Codex Game Studios code review for implementation files, checking ADR compliance, standards, architecture, testability, performance, and game-specific risks. This is the Codex-native replacement for the original Claude Code `/code-review` workflow.
+metadata:
+  short-description: Review implementation code
+---
+
+# Codex Game Studios Code Review
+
+This skill is read-only. It prioritizes bugs, behavioral regressions,
+architecture violations, missing tests, and implementation risks.
+
+## Inputs To Read
+
+- Target files or directories.
+- `AGENTS.md` and relevant directory `AGENTS.md`.
+- `.claude/docs/technical-preferences.md`.
+- Relevant `.claude/rules/*.md` based on path.
+- Referenced story file, if provided or inferable.
+- Referenced ADRs.
+- Relevant GDDs.
+- Existing tests.
+- Original source workflow, only if more detail is needed:
+  `.claude/skills/code-review/SKILL.md`.
+
+## Review Areas
+
+- ADR compliance: forbidden patterns, drift, or missing decision linkage.
+- Standards compliance: doc comments, file structure, data-driven values,
+  dependency injection, no hidden singletons for game state.
+- Architecture: layer separation, dependency direction, no circular ownership,
+  UI does not own core state.
+- SOLID/testability: seams for tests, no fat interfaces, no untestable hidden
+  state.
+- Game-specific risks: delta time, hot-path allocations, null/empty states,
+  resource cleanup, thread safety, save/load correctness.
+- Engine risks: API compatibility against `docs/engine-reference/`.
+- Test coverage: acceptance criteria have unit/integration/manual evidence as
+  appropriate.
+
+## Output
+
+Follow code review style:
+
+- Findings first, ordered by severity.
+- Include file and line references where possible.
+- Avoid long summaries before findings.
+
+Verdicts:
+
+- `APPROVED`: no blocking findings.
+- `APPROVED WITH SUGGESTIONS`: only non-blocking improvements.
+- `CHANGES REQUIRED`: bugs, architecture violations, missing required tests, or
+  story acceptance gaps.
+
+If no findings, say so and identify residual risks or testing gaps.
+
+Do not edit files unless the user explicitly asks to fix findings.

--- a/.agents/skills/cgs-consistency-check/SKILL.md
+++ b/.agents/skills/cgs-consistency-check/SKILL.md
@@ -1,0 +1,90 @@
+---
+name: cgs-consistency-check
+description: Use to run a Codex Game Studios cross-GDD consistency check against the entity registry, detecting conflicting entity, item, formula, and constant values, stale registry entries, unverifiable references, and required fixes before architecture. This is the Codex-native replacement for the original Claude Code `/consistency-check` workflow.
+metadata:
+  short-description: Check GDD consistency
+---
+
+# Codex Game Studios Consistency Check
+
+This skill verifies that GDDs and the entity registry agree on shared facts. It
+is a safety net before cross-GDD review, architecture, and ADR work.
+
+## Modes
+
+- `full`: check all registered entries.
+- `since-last-review`: check GDDs changed since the latest cross review.
+- `entity:[name]`: check one entity.
+- `item:[name]`: check one item.
+
+Default to `full`.
+
+## Inputs To Read
+
+- `design/registry/entities.yaml`; stop if missing or empty.
+- In-scope GDDs under `design/gdd/`, excluding concept/index/pillars docs.
+- Latest `design/gdd/gdd-cross-review-*.md`, if using `since-last-review`.
+- Git history only when needed to determine stale registry context.
+- Original source workflow, only if more detail is needed:
+  `.claude/skills/consistency-check/SKILL.md`.
+
+## Grep-First Scan
+
+Build maps from the registry:
+
+- entities.
+- items.
+- formulas.
+- constants.
+
+Search in-scope GDDs for each registered name and inspect local context before
+full-reading any document. Full-read only sections involved in suspected
+conflicts.
+
+Detect:
+
+- `CONFLICT`: different values for the same named fact.
+- `STALE REGISTRY`: source GDD changed but registry is behind.
+- `UNVERIFIABLE`: reference exists but has no comparable value.
+
+The source GDD listed in the registry is normally authoritative unless the user
+confirms a design change.
+
+## Report
+
+Generate:
+
+- Registry counts by entry type.
+- GDDs scanned.
+- Conflicts that must resolve before architecture.
+- Stale registry entries.
+- Unverifiable references.
+- Clean entry count.
+- Verdict: `PASS` or `CONFLICTS FOUND`.
+
+For each conflict, include source, conflicting document, exact differing value,
+and recommended resolution.
+
+## Optional Writes
+
+Ask before any file changes.
+
+Allowed updates after approval:
+
+- update stale registry values in `design/registry/entities.yaml`.
+- add new cross-system entries that appear in more than one GDD.
+- mark deprecated entries instead of deleting.
+- append to `docs/consistency-failures.md` only if it already exists.
+
+Do not silently resolve design conflicts.
+
+## Completion
+
+Finish with:
+
+- verdict.
+- unresolved conflict count.
+- stale registry count.
+- files updated, if any.
+- next recommended Codex request: fix GDDs, rerun consistency check,
+  review all GDDs, or create architecture.

--- a/.agents/skills/cgs-content-audit/SKILL.md
+++ b/.agents/skills/cgs-content-audit/SKILL.md
@@ -1,0 +1,83 @@
+---
+name: cgs-content-audit
+description: Use to audit Codex Game Studios planned content counts against implemented content for one system or the full project, identifying specified vs found counts, gaps, high-priority MVP gaps, and backlog follow-up. This is the Codex-native replacement for the original Claude Code `/content-audit` workflow.
+metadata:
+  short-description: Audit planned content gaps
+---
+
+# Codex Game Studios Content Audit
+
+This skill compares GDD-specified content against files present in the project.
+Counts are approximate and should be manually verified for high-priority gaps.
+
+## Scope
+
+- no argument: full audit.
+- system name: audit one system.
+- `summary`: print summary only and do not write a file.
+
+## Inputs To Read
+
+- `design/gdd/systems-index.md`.
+- In-scope GDDs under `design/gdd/`.
+- Relevant content directories under `assets/` and `src/`.
+- Existing epics/stories if backlog follow-up is requested.
+- Original source workflow, only if more detail is needed:
+  `.claude/skills/content-audit/SKILL.md`.
+
+## Extract Planned Content
+
+Use a grep-first pass for count/list language:
+
+- enemies, characters, NPCs.
+- levels, maps, areas, stages.
+- items, weapons, equipment, loot.
+- abilities, skills, spells.
+- dialogue, conversations, cutscenes.
+- quests, missions, objectives.
+- explicit named content lists.
+
+Record unspecified qualitative content as an auditability gap.
+
+## Scan Implemented Content
+
+Count likely implemented files:
+
+- scenes/levels/maps in `assets/` and `src/`.
+- enemy, character, item, ability, quest, and dialogue data files.
+- engine-specific scene/prefab/resource files.
+
+Note caveats where files may be editor-only, test-only, UI-only, or otherwise
+not shippable content.
+
+## Report
+
+Generate:
+
+- Summary: total specified, total found, gap count and percentage, scope.
+- Gap Table: system, content type, specified, found, gap, status.
+- Status: `COMPLETE`, `IN PROGRESS`, `EARLY`, or `NOT STARTED`.
+- HIGH PRIORITY Gaps for MVP/Vertical Slice blockers.
+- Per-System Breakdown.
+- Unspecified Content Counts.
+- Recommendations.
+
+Flag `NOT STARTED` or `EARLY` MVP content as high priority.
+
+## Write Output
+
+For full or single-system audits, present the report first. After approval or
+explicit write request, write `docs/content-audit-[date].md`.
+
+For `summary`, do not write.
+
+## Completion
+
+Finish with:
+
+- audit scope.
+- highest priority gaps.
+- total gap percentage.
+- report path if written.
+- next recommended Codex request: sprint plan, create stories, quick design, or
+  design system update.

--- a/.agents/skills/cgs-create-architecture/SKILL.md
+++ b/.agents/skills/cgs-create-architecture/SKILL.md
@@ -1,0 +1,85 @@
+---
+name: cgs-create-architecture
+description: Use to create or update the Codex Game Studios master architecture document from approved GDDs, systems index, technical preferences, engine reference docs, and existing ADRs. This is the Codex-native replacement for the original Claude Code `/create-architecture` workflow.
+metadata:
+  short-description: Create the architecture blueprint
+---
+
+# Codex Game Studios Create Architecture
+
+This skill creates `docs/architecture/architecture.md`: the whole-game technical
+blueprint that ties GDD systems to modules, data flow, API boundaries, and ADR
+coverage.
+
+## Inputs To Read
+
+- `.claude/docs/technical-preferences.md`; engine must be configured.
+- `docs/engine-reference/<engine>/VERSION.md`, `breaking-changes.md`,
+  `deprecated-apis.md`, `current-best-practices.md`, and relevant module docs.
+- `design/gdd/game-concept.md`.
+- `design/gdd/systems-index.md`.
+- Approved or in-scope system GDDs under `design/gdd/`.
+- Existing `docs/architecture/adr-*.md`.
+- `docs/architecture/tr-registry.yaml`, if present.
+- `.claude/docs/templates/technical-design-document.md` and related architecture
+  templates, if useful.
+- Original source workflow, only if deeper detail is needed:
+  `.claude/skills/create-architecture/SKILL.md`.
+
+Stop if no engine is configured. Architecture decisions depend on engine and
+version.
+
+## Build Technical Requirements Baseline
+
+Extract technical requirements from GDDs:
+
+- Data structures and ownership.
+- Cross-system communication.
+- Save/load and persistence.
+- Input, UI, audio, VFX, physics, animation, networking, AI, or rendering needs.
+- Performance and timing constraints.
+- Engine APIs or capabilities implied by design.
+
+Assign stable provisional IDs like `TR-[system]-001` when a registry does not
+already provide them.
+
+## Architecture Sections
+
+Draft these sections:
+
+- System Layer Map: Platform, Foundation, Core, Feature, Presentation, Polish.
+- Module Ownership: owns, exposes, consumes, and engine APIs used.
+- Data Flow: frame update, event/signal path, save/load, initialization order.
+- API Boundaries: public contracts, invariants, and caller guarantees.
+- Engine Compatibility: version, high-risk domains, deprecated APIs to avoid.
+- ADR Coverage: existing ADRs, missing ADRs, and conflicts.
+- Traceability: GDD/system requirement to architecture module and ADR status.
+- Open Questions and Risks.
+
+Flag post-cutoff engine risks instead of guessing.
+
+## Write Output
+
+Before editing, present:
+
+- GDD count read.
+- Requirement count.
+- Proposed architecture layers.
+- Missing ADRs.
+- High-risk engine domains.
+
+Ask whether to write or update `docs/architecture/architecture.md`. After
+approval, create `docs/architecture/` if needed and write the document.
+
+Preserve useful existing architecture content. Do not replace an existing
+architecture file wholesale unless the user explicitly approves a rewrite.
+
+## Completion
+
+Finish with:
+
+- Architecture path.
+- Required ADR list.
+- Traceability gaps.
+- Next recommended Codex request: create an ADR, review architecture, or create
+  the control manifest.

--- a/.agents/skills/cgs-create-control-manifest/SKILL.md
+++ b/.agents/skills/cgs-create-control-manifest/SKILL.md
@@ -1,0 +1,81 @@
+---
+name: cgs-create-control-manifest
+description: Use to generate the Codex Game Studios control manifest from Accepted ADRs, technical preferences, and engine reference constraints. This is the Codex-native replacement for the original Claude Code `/create-control-manifest` workflow.
+metadata:
+  short-description: Generate programmer rules manifest
+---
+
+# Codex Game Studios Create Control Manifest
+
+This skill generates `docs/architecture/control-manifest.md`: the flat,
+actionable rules sheet programmers use during story implementation.
+
+## Inputs To Read
+
+- Accepted `docs/architecture/adr-*.md` files.
+- `.claude/docs/technical-preferences.md`.
+- `docs/engine-reference/<engine>/VERSION.md`.
+- `docs/engine-reference/<engine>/deprecated-apis.md`.
+- `docs/engine-reference/<engine>/current-best-practices.md`, if present.
+- Original source workflow, only if more detail is needed:
+  `.claude/skills/create-control-manifest/SKILL.md`.
+
+Skip Proposed, Deprecated, and Superseded ADRs.
+
+## Extract Rules
+
+From Accepted ADRs, extract:
+
+- Required patterns.
+- Forbidden approaches.
+- Performance guardrails.
+- Engine API constraints.
+- Layer-specific rules.
+- Source ADR for every rule.
+
+From technical preferences, extract:
+
+- Naming conventions.
+- Performance budgets.
+- Approved libraries/addons.
+- Forbidden patterns.
+
+From engine references, extract:
+
+- Deprecated APIs as forbidden entries.
+- Current best practices as required entries when directly applicable.
+
+Do not invent unsourced rules.
+
+## Write Output
+
+Before writing, present rule counts by layer:
+
+- Foundation.
+- Core.
+- Feature.
+- Presentation.
+- Global.
+
+After approval, write `docs/architecture/control-manifest.md` with:
+
+- Engine and version.
+- Last Updated.
+- Manifest Version.
+- ADRs covered.
+- Required patterns.
+- Forbidden approaches.
+- Performance guardrails.
+- Naming conventions.
+- Approved libraries.
+- Forbidden APIs.
+
+## Completion
+
+Finish with:
+
+- Manifest path.
+- ADRs covered.
+- ADRs skipped and why.
+- Any missing technical preference values.
+- Next recommended Codex request: create stories or run story readiness.

--- a/.agents/skills/cgs-create-epics/SKILL.md
+++ b/.agents/skills/cgs-create-epics/SKILL.md
@@ -1,0 +1,85 @@
+---
+name: cgs-create-epics
+description: Use to translate approved Codex Game Studios GDDs and architecture into epic folders and EPIC.md files, one epic per architectural module or system. This is the Codex-native replacement for the original Claude Code `/create-epics` workflow.
+metadata:
+  short-description: Create implementation epics
+---
+
+# Codex Game Studios Create Epics
+
+This skill creates `production/epics/[epic-slug]/EPIC.md` files. Epics define
+bounded implementation scope; they do not create stories.
+
+## Modes
+
+- All eligible systems.
+- A layer: Foundation, Core, Feature, Presentation, or Polish.
+- One system or module.
+
+## Inputs To Read
+
+- `design/gdd/systems-index.md`.
+- In-scope system GDDs under `design/gdd/`.
+- `docs/architecture/architecture.md`.
+- Relevant `docs/architecture/adr-*.md`.
+- `docs/architecture/control-manifest.md`, if present.
+- `docs/architecture/tr-registry.yaml`, if present.
+- Engine version from `.claude/docs/technical-preferences.md` or
+  `docs/engine-reference/<engine>/VERSION.md`.
+- Original source workflow, only if more detail is needed:
+  `.claude/skills/create-epics/SKILL.md`.
+
+Stop if systems index, GDDs, or architecture are missing unless the user
+explicitly accepts placeholder epics.
+
+## Epic Definition
+
+For each in-scope system/module, determine:
+
+- Layer.
+- GDD path.
+- Architecture module.
+- Governing ADRs.
+- Engine risk from ADRs.
+- TR/GDD requirements covered.
+- Untraced requirements or missing ADRs.
+- Dependencies on other epics.
+
+Warn when requirements lack Accepted ADR coverage. The epic may be created, but
+stories tied to unaccepted or missing ADRs should be marked blocked.
+
+## Write Output
+
+Before writing, present:
+
+- Epic name.
+- Scope summary.
+- Governing ADRs.
+- Requirement coverage.
+- Gaps and risks.
+
+After approval, create:
+
+- `production/epics/[epic-slug]/EPIC.md`.
+- Update or create `production/epics/index.md`.
+
+Minimum `EPIC.md` sections:
+
+- Overview.
+- Layer and architecture module.
+- GDD link.
+- Governing ADRs.
+- GDD/TR requirements.
+- Dependencies.
+- Definition of Done.
+- Story creation status.
+- Next step: create stories.
+
+## Completion
+
+Finish with:
+
+- Epics written.
+- Epics skipped or blocked.
+- Requirements lacking ADR coverage.
+- Next recommended Codex request: create stories for one epic.

--- a/.agents/skills/cgs-create-stories/SKILL.md
+++ b/.agents/skills/cgs-create-stories/SKILL.md
@@ -1,0 +1,90 @@
+---
+name: cgs-create-stories
+description: Use to break a Codex Game Studios epic into implementable story markdown files with TR-ID traceability, governing ADRs, acceptance criteria, story type, dependencies, and test evidence requirements. This is the Codex-native replacement for the original Claude Code `/create-stories` workflow.
+metadata:
+  short-description: Break an epic into stories
+---
+
+# Codex Game Studios Create Stories
+
+This skill creates implementable story files under an epic directory. Run it per
+epic after `cgs-create-epics`.
+
+## Inputs To Read
+
+- `production/epics/[epic-slug]/EPIC.md`.
+- The epic's GDD.
+- Governing ADRs listed in the epic.
+- `docs/architecture/control-manifest.md`.
+- `docs/architecture/tr-registry.yaml`.
+- `.claude/docs/technical-preferences.md`.
+- Original source workflow, only if more detail is needed:
+  `.claude/skills/create-stories/SKILL.md`.
+
+Stop if the epic references ADR files that do not exist. Stories need concrete
+implementation guidance.
+
+## Story Types
+
+Classify each story by highest implementation risk:
+
+- Logic: formulas, state transitions, rules, AI decisions.
+- Integration: two or more systems interacting.
+- Visual/Feel: animation, VFX, audio sync, responsiveness, game feel.
+- UI: screens, HUD, menus, controls, accessibility.
+- Config/Data: balance values or data file changes only.
+
+## Decompose
+
+For each GDD acceptance criterion:
+
+1. Group related criteria into one focused story.
+2. Keep each story small enough for one focused implementation session.
+3. Order by dependency: foundation behavior, core logic, edge cases, integration,
+   UI/visual polish.
+4. Assign TR-ID from registry. If missing, use a placeholder and flag it.
+5. Assign governing ADR. If ADR is Proposed, mark story Blocked.
+6. Define evidence path:
+   - Logic: `tests/unit/[system]/[story-slug]_test.[ext]`.
+   - Integration: `tests/integration/[system]/[story-slug]_test.[ext]`.
+   - Visual/Feel or UI: `production/qa/evidence/[story-slug]-evidence.md`.
+   - Config/Data: smoke check evidence.
+
+## Write Output
+
+Before writing, present the full story list:
+
+- Story number and title.
+- Type.
+- TR-ID.
+- ADR.
+- Evidence path.
+- Dependencies.
+- Blocked/Ready status.
+
+After approval, write:
+
+`production/epics/[epic-slug]/story-[NNN]-[slug].md`
+
+Minimum story sections:
+
+- Header with Epic, Status, Layer, Type, Manifest Version.
+- Context: GDD, TR-ID, ADR, engine risk.
+- Acceptance Criteria.
+- Implementation Notes from ADR.
+- Out of Scope.
+- QA Test Cases or Manual Verification.
+- Test Evidence.
+- Dependencies.
+- Developer Notes.
+
+Update `EPIC.md` story count/status only after user approval.
+
+## Completion
+
+Finish with:
+
+- Story files written.
+- Blocked stories and why.
+- Missing TR IDs or ADRs.
+- Next recommended Codex request: story readiness or dev story implementation.

--- a/.agents/skills/cgs-design-review/SKILL.md
+++ b/.agents/skills/cgs-design-review/SKILL.md
@@ -1,0 +1,113 @@
+---
+name: cgs-design-review
+description: Use to review a Codex Game Studios design document or system GDD for completeness, consistency, implementability, dependencies, and readiness for implementation. This is the Codex-native replacement for the original Claude Code `/design-review` workflow.
+metadata:
+  short-description: Review a design document
+---
+
+# Codex Game Studios Design Review
+
+This skill reviews a design document before it is handed to implementation.
+Default behavior is read-only unless the user explicitly asks to revise or log
+the review.
+
+## Inputs To Read
+
+- Target design document path.
+- `AGENTS.md`, `design/AGENTS.md`, and relevant directory instructions.
+- `design/gdd/game-concept.md`, if present.
+- Related GDDs under `design/gdd/`.
+- `design/registry/entities.yaml`, if present.
+- Prior review log at `design/gdd/reviews/[doc-name]-review-log.md`, if present.
+- Original source workflow, only if more detail is needed:
+  `.claude/skills/design-review/SKILL.md`.
+
+If no path is provided, ask for one or infer the most recently edited GDD only
+if that is unambiguous.
+
+## Completeness Checklist
+
+For system GDDs, verify these 8 sections:
+
+1. Overview
+2. Player Fantasy
+3. Detailed Rules
+4. Formulas
+5. Edge Cases
+6. Dependencies
+7. Tuning Knobs
+8. Acceptance Criteria
+
+Accept equivalent headings such as "Detailed Design" only if the content is
+specific enough for implementation.
+
+## Review Areas
+
+Assess:
+
+- Completeness: missing or placeholder sections.
+- Internal consistency: rules, formulas, edge cases, and tuning ranges agree.
+- Implementability: a programmer can build it without guessing.
+- Testability: acceptance criteria are measurable.
+- Dependency graph: listed dependencies exist or are explicitly provisional.
+- Cross-system consistency: no contradictions with existing GDDs or registry
+  facts.
+- Pillar alignment: mechanics support the stated game pillars and fantasy.
+- Scope signal: S, M, L, or XL based on dependencies, formulas, systems touched,
+  and likely ADR needs.
+
+## Optional Depth
+
+If the user asks for a full/adversarial review, simulate domain lenses locally:
+
+- Game design: fantasy, fun, dominant strategies, cognitive load.
+- Systems design: formula bounds, data ownership, tuning surfaces.
+- QA: acceptance criteria and edge cases.
+- Technical: architecture or engine risks.
+- UX/narrative/economy only when the document touches those domains.
+
+Do not spawn subagents unless the user explicitly asks for delegated review.
+
+## Output
+
+Use this format:
+
+```text
+Design Review: [Document]
+Verdict: APPROVED | NEEDS REVISION | MAJOR REVISION NEEDED
+Scope signal: S | M | L | XL
+
+Completeness:
+- [X/8] required sections present
+
+Required before implementation:
+- [blocking issue]
+
+Recommended revisions:
+- [important but not blocking]
+
+Dependency graph:
+- [dependency] - exists / missing / provisional
+
+Residual risks:
+- [risk or none]
+```
+
+## Verdict Rules
+
+- `APPROVED`: complete enough to implement; only minor improvements remain.
+- `NEEDS REVISION`: implementation would require guessing or risk, but fixes are
+  localized.
+- `MAJOR REVISION NEEDED`: concept, rules, dependencies, or acceptance criteria
+  are too incomplete or contradictory to implement safely.
+
+## Optional Writes
+
+Only if the user approves:
+
+- Append review summary to `design/gdd/reviews/[doc-name]-review-log.md`.
+- Update `design/gdd/systems-index.md` status.
+- Revise the GDD to address blockers.
+
+Preserve existing design content and avoid overwriting authored sections without
+explicit approval.

--- a/.agents/skills/cgs-design-system/SKILL.md
+++ b/.agents/skills/cgs-design-system/SKILL.md
@@ -1,0 +1,127 @@
+---
+name: cgs-design-system
+description: Use to author or retrofit a single Codex Game Studios system GDD section-by-section, using the game concept, systems index, dependencies, and engine constraints. This is the Codex-native replacement for the original Claude Code `/design-system` workflow.
+metadata:
+  short-description: Write one system GDD
+---
+
+# Codex Game Studios Design System
+
+This skill writes or retrofits one system GDD in `design/gdd/`. It should be
+used after the game concept and systems index exist.
+
+## Modes
+
+- New GDD: user names a system, such as "combat" or "inventory".
+- Next GDD: user asks to design the next system from the systems index.
+- Retrofit: user provides an existing GDD path and wants missing sections filled
+  without overwriting existing content.
+
+## Inputs To Read
+
+- `design/gdd/game-concept.md`; required.
+- `design/gdd/systems-index.md`; required unless the user explicitly accepts an
+  off-index GDD.
+- `design/registry/entities.yaml`, if present.
+- `docs/consistency-failures.md`, if present.
+- `.claude/docs/technical-preferences.md`.
+- Relevant `docs/engine-reference/<engine>/` files, if an engine is configured.
+- Relevant upstream/downstream GDDs listed in the systems index.
+- `.claude/docs/templates/game-design-document.md` for the output shape.
+- Original source workflow, only if more detail is needed:
+  `.claude/skills/design-system/SKILL.md`.
+
+If required concept or systems index files are missing, stop and recommend the
+appropriate prior workflow.
+
+## Select The Target System
+
+If no system is provided:
+
+1. Read `design/gdd/systems-index.md`.
+2. Identify the highest-priority `Not Started` system.
+3. Ask whether to design it or choose a different system.
+
+Normalize new GDD filenames to kebab-case, for example `combat-system.md`.
+
+For retrofit mode:
+
+- Read the existing GDD.
+- Identify the 8 required sections.
+- List complete, missing, and placeholder-only sections.
+- Ask before filling only the missing or incomplete sections.
+- Never overwrite complete existing content.
+
+## Context Summary
+
+Before designing, present a concise brief:
+
+- System name, priority, and layer.
+- Upstream dependencies and whether their GDDs exist.
+- Downstream dependents and expectations.
+- Existing decisions to respect.
+- Relevant pillars and anti-pillars.
+- Relevant registry facts that must not be contradicted.
+- Engine/domain constraints or missing engine setup.
+
+If dependencies are undesigned, either recommend designing them first or define
+explicit provisional contracts.
+
+## Required GDD Sections
+
+Author these sections in order:
+
+1. Overview
+2. Player Fantasy
+3. Detailed Rules
+4. Formulas
+5. Edge Cases
+6. Dependencies
+7. Tuning Knobs
+8. Acceptance Criteria
+
+Also include a short Game Feel subsection when the system affects moment-to-
+moment player experience.
+
+## Section Workflow
+
+For each section:
+
+1. Explain what the section must decide.
+2. Surface constraints from concept, dependencies, engine docs, and registry.
+3. Ask only the decisions that are actually needed.
+4. Present a concise draft.
+5. Ask whether to write or revise.
+6. Write the approved section before moving on.
+
+For simple low-risk sections, make reasonable assumptions and mark them as
+assumptions instead of over-questioning the user.
+
+## Write Output
+
+For a new GDD:
+
+- Create the skeleton after the user confirms the target system.
+- Fill sections incrementally.
+- Use `Status: In Design` until the user accepts the full GDD.
+
+For retrofit:
+
+- Edit only missing or placeholder sections.
+- Preserve existing authored content.
+
+After all sections are complete:
+
+- Summarize unresolved assumptions.
+- Recommend a design review.
+- Update `design/gdd/systems-index.md` status only if the user approves.
+
+## Completion
+
+Finish with:
+
+- GDD path.
+- Sections completed.
+- Open assumptions or conflicts.
+- Next recommended Codex request: design review, next system, or systems index
+  status update.

--- a/.agents/skills/cgs-dev-story/SKILL.md
+++ b/.agents/skills/cgs-dev-story/SKILL.md
@@ -1,0 +1,154 @@
+---
+name: cgs-dev-story
+description: Use to implement a Codex Game Studios production story by loading the story, GDD requirement, ADR, control manifest, engine preferences, writing code and tests, and summarizing acceptance-criteria coverage. This is the Codex-native replacement for the original Claude Code `/dev-story` workflow.
+metadata:
+  short-description: Implement a production story
+---
+
+# Codex Game Studios Dev Story
+
+This skill bridges planning and implementation. It reads a story file, loads
+the governing design and architecture context, implements the change, writes or
+updates tests, and reports acceptance-criteria coverage.
+
+## Preconditions
+
+Use after story readiness has been checked or when the user explicitly accepts
+the risk of implementing without that check.
+
+Expected flow:
+
+1. QA/test plan for sprint or feature.
+2. Story readiness check.
+3. Dev story implementation.
+4. Code review.
+5. Story done verification.
+
+## Find The Story
+
+If a story path is provided, read it.
+
+If not:
+
+- Check `production/session-state/active.md` for an active story.
+- Otherwise list ready stories from `production/epics/**/*.md` and ask which one
+  to implement.
+
+## Required Context
+
+Read before editing code:
+
+- Story file: title, ID, status, layer, type, acceptance criteria, dependencies,
+  out-of-scope, test evidence path, TR-ID, ADR, manifest version.
+- `docs/architecture/tr-registry.yaml`: current requirement text for the TR-ID.
+- Governing ADR referenced by the story.
+- `docs/architecture/control-manifest.md`, if present.
+- `.claude/docs/technical-preferences.md`.
+- Relevant GDDs under `design/gdd/`.
+- Relevant engine references under `docs/engine-reference/`, if engine is
+  configured.
+- Existing source and tests in the target area.
+- Original source workflow, only if more detail is needed:
+  `.claude/skills/dev-story/SKILL.md`.
+
+Stop before implementation if the TR registry or governing ADR is required by
+the story but missing. Report the blocker and recommended fix.
+
+## Dependency And Scope Checks
+
+Before editing:
+
+- Verify dependency stories are `Done` or `Complete`, or ask the user to accept
+  dependency risk.
+- Compare story manifest version to the current control manifest, if both exist.
+- Identify files likely in scope.
+- Identify out-of-scope boundaries that must not be crossed.
+
+If unexpected unrelated local changes exist in files you need to edit, stop and
+ask how to proceed.
+
+## Implementation Routing
+
+Use role guidance locally rather than guaranteed named subagents:
+
+- Foundation systems: engine-programmer lens.
+- UI stories: UI programmer lens.
+- Gameplay mechanics: gameplay-programmer lens.
+- AI/pathfinding: AI programmer lens.
+- Networking: network-programmer lens.
+- Config/data: direct data edit, usually no code architecture change.
+- Engine-specific code: consult engine reference docs and apply the selected
+  engine specialist lens.
+
+Do not spawn subagents unless the user explicitly asks for delegation or
+parallel implementation.
+
+## Implement
+
+- Keep within the story's acceptance criteria and out-of-scope boundaries.
+- Respect ADR decisions and control manifest rules.
+- Keep gameplay values data-driven.
+- Add doc comments for public APIs.
+- Prefer minimal, coherent changes over broad refactors.
+- For Config/Data stories, report exact value changes.
+
+## Tests And Evidence
+
+- Logic and integration stories require automated tests.
+- Visual/Feel and UI stories require manual evidence notes if automated tests
+  are not practical.
+- Config/Data stories usually need smoke-check evidence.
+
+Test expectations:
+
+- Cover each acceptance criterion where automatable.
+- Test formula bounds and edge cases from the GDD.
+- Avoid nondeterminism, external I/O, and time-dependent assertions unless the
+  project test framework explicitly supports them.
+
+Run the relevant test command when available. If the engine or test framework is
+not configured, state that verification could not be run and why.
+
+## Session State
+
+After implementation, append a concise entry to
+`production/session-state/active.md` if the user has not asked to avoid session
+state updates:
+
+```text
+## Session Extract - dev story [YYYY-MM-DD]
+- Story: [path] - [title]
+- Files changed: [paths]
+- Test written: [path or manual evidence]
+- Blockers: [none or summary]
+- Next: code review, then story done verification
+```
+
+Create `production/session-state/` if needed.
+
+## Output
+
+Use this format:
+
+```text
+Implementation: [Story Title]
+
+Files changed:
+- [path] - [what changed]
+
+Acceptance criteria:
+- [x] [criterion] - [implementation/test evidence]
+- [ ] [criterion] - [why not complete]
+
+Tests:
+- [command] - passed/failed/not run
+
+Deviations:
+- [none or explicit scope/ADR/test deviation]
+
+Next:
+- Run code review.
+- Run story done verification.
+```
+
+Do not mark a story done automatically. That belongs to story done verification.

--- a/.agents/skills/cgs-estimate/SKILL.md
+++ b/.agents/skills/cgs-estimate/SKILL.md
@@ -1,0 +1,72 @@
+---
+name: cgs-estimate
+description: Use to generate a read-only Codex Game Studios effort estimate for a task by analyzing affected systems, likely files, dependencies, test needs, historical sprint data, complexity, risks, and confidence. This is the Codex-native replacement for the original Claude Code `/estimate` workflow.
+metadata:
+  short-description: Estimate task effort
+---
+
+# Codex Game Studios Estimate
+
+This skill is read-only. It produces a scoped effort estimate with assumptions
+and confidence instead of a single-point guess.
+
+## Task Input
+
+Read the task description from the user. If it is too vague to estimate, ask
+for the missing scope, target system, acceptance criteria, or constraints before
+continuing.
+
+## Inputs To Read
+
+- `AGENTS.md` and relevant directory instructions.
+- `.claude/docs/technical-preferences.md`.
+- Relevant GDDs under `design/gdd/`.
+- Relevant architecture docs, ADRs, epics, and stories.
+- Existing source and tests likely affected by the task.
+- Past sprint plans, retrospectives, and velocity data under `production/`.
+- Original source workflow, only if more detail is needed:
+  `.claude/skills/estimate/SKILL.md`.
+
+## Analyze
+
+Assess:
+
+- systems affected.
+- likely files/modules to modify.
+- new code vs modification ratio.
+- integration points.
+- test coverage needed.
+- existing patterns available.
+- dependencies and unfinished prerequisite work.
+- ambiguity, new technology, platform, engine, or performance risk.
+
+Round estimates to half-day increments. Do not imply false precision with hour
+estimates for multi-day work.
+
+## Estimate Output
+
+Generate:
+
+- Task Description.
+- Complexity Assessment table.
+- Key files likely affected.
+- Effort Estimate: optimistic, expected, pessimistic.
+- Recommended budget: expected estimate.
+- Confidence: High, Medium, or Low.
+- Risk Factors table.
+- Dependencies table.
+- Suggested Breakdown with subtasks.
+- Notes and assumptions.
+
+Always give a range. Do not silently pad. Call out risk explicitly so the user
+can decide whether to reduce scope or fund a spike.
+
+## Completion
+
+Finish with:
+
+- recommended budget.
+- confidence level.
+- biggest risk factor.
+- next recommended Codex request: prototype/spike, create stories, or sprint
+  plan update.

--- a/.agents/skills/cgs-gate-check/SKILL.md
+++ b/.agents/skills/cgs-gate-check/SKILL.md
@@ -1,0 +1,118 @@
+---
+name: cgs-gate-check
+description: Use to validate whether a Codex Game Studios project is ready to advance from one development phase to the next, producing a PASS, CONCERNS, or FAIL verdict. This is the Codex-native replacement for the original Claude Code `/gate-check` workflow.
+metadata:
+  short-description: Validate phase readiness
+---
+
+# Codex Game Studios Gate Check
+
+This skill performs a phase gate review. It is prescriptive: "are we ready to
+advance?" For diagnostic "where are we?", use `cgs-help`.
+
+## Inputs To Read
+
+- `.claude/docs/workflow-catalog.yaml`: phase sequence and required artifacts.
+- `production/stage.txt`, if present.
+- `production/review-mode.txt`, if present.
+- `docs/consistency-failures.md`, if present.
+- Artifacts required by the current or requested phase.
+- Original source workflow, only if a detailed checklist is needed:
+  `.claude/skills/gate-check/SKILL.md`.
+
+## Determine Gate
+
+If the user names a target phase, validate readiness to enter that phase.
+
+If no target is named:
+
+1. Infer current phase using `production/stage.txt` first, then artifacts.
+2. Identify the next phase from `workflow-catalog.yaml`.
+3. Confirm the inferred transition before doing a long review.
+
+Phase sequence:
+
+1. Concept
+2. Systems Design
+3. Technical Setup
+4. Pre-Production
+5. Production
+6. Polish
+7. Release
+
+## Review Mode
+
+- `solo`: artifact and basic quality checks only.
+- `lean`: artifact and core quality checks; default.
+- `full`: deeper cross-domain scrutiny, still performed locally unless the user
+  explicitly asks for delegated or parallel agent review.
+
+Do not spawn subagents unless the user explicitly asks for delegation.
+
+## Checks
+
+Use `workflow-catalog.yaml` as the primary checklist:
+
+- Verify required artifact globs.
+- Verify `min_count` requirements.
+- Verify `artifact.pattern` requirements.
+- For files that exist, check they have meaningful content, not only template
+  headings.
+- For manual notes, report that human confirmation is needed.
+
+Add phase-specific scrutiny:
+
+- Concept gate: concept, pillars, core loop, target audience, visual identity.
+- Systems gate: systems index, MVP GDD coverage, design reviews, dependency
+  consistency.
+- Technical gate: engine setup, technical preferences, ADRs, architecture docs,
+  engine references, test setup, accessibility foundation.
+- Pre-production gate: prototype, vertical slice evidence, UX specs, epics,
+  stories, sprint plan.
+- Production gate: implemented core loop, tests, QA plan, smoke check, playtest
+  evidence, critical bugs.
+- Polish gate: feature/content completeness, localization readiness, QA signoff,
+  balance/performance checks.
+- Release gate: release checklist, packaging, legal/store metadata, no
+  medium-or-higher known bugs unless explicitly accepted.
+
+## Verdict Rules
+
+- `PASS`: required artifacts exist and quality risks are minor.
+- `CONCERNS`: required artifacts mostly exist, but there are explicit risks the
+  user can choose to accept.
+- `FAIL`: required artifacts are missing, core quality checks fail, or a manual
+  gate item is unresolved and materially blocks the next phase.
+
+Never silently advance on `FAIL`.
+
+## Output
+
+Use this format:
+
+```text
+Gate: [Current] -> [Next]
+Verdict: PASS | CONCERNS | FAIL
+
+Required artifacts:
+- PASS/FAIL [artifact] - [finding]
+
+Blockers:
+- [only FAIL items]
+
+Concerns:
+- [risks that could be accepted]
+
+Recommended next action:
+- [one concrete Codex request]
+```
+
+## Stage Update
+
+If the verdict is `PASS`, ask whether to update `production/stage.txt` to the
+new phase. Write only after approval.
+
+If the verdict is `CONCERNS`, ask whether the user accepts the risks before
+updating `production/stage.txt`.
+
+If the verdict is `FAIL`, do not update stage state.

--- a/.agents/skills/cgs-help/SKILL.md
+++ b/.agents/skills/cgs-help/SKILL.md
@@ -1,0 +1,89 @@
+---
+name: cgs-help
+description: Use when the user asks what to do next in Codex Game Studios, is stuck, wants project-stage guidance, or needs a Codex-native replacement for the original Claude Code `/help` workflow.
+metadata:
+  short-description: Find the next game-dev workflow step
+---
+
+# Codex Game Studios Help
+
+This skill is read-only. It inspects the current project state and tells the
+user the next required step in the game-development pipeline.
+
+## Inputs To Read
+
+- `.claude/docs/workflow-catalog.yaml`: authoritative phase and step catalog.
+- `production/stage.txt`: explicit current phase, if present.
+- `production/session-state/active.md`: current task or handoff context.
+- `production/sprint-status.yaml`: production story status, if present.
+- Artifact paths referenced by the workflow catalog.
+- `.agents/skills/*/SKILL.md` and `.claude/skills/*/SKILL.md` when the user
+  asks what workflows are available.
+
+## Determine Current Phase
+
+Use this order:
+
+1. `production/stage.txt` if it exists and has content.
+2. Otherwise infer from artifacts, checking most advanced state first:
+   - 10+ source files in `src/`: Production
+   - `production/stories/*.md` or `production/epics/**/*.md`: Pre-Production
+   - `docs/architecture/adr-*.md`: Technical Setup
+   - `design/gdd/systems-index.md`: Systems Design
+   - `design/gdd/game-concept.md`: Concept
+   - Otherwise: Concept
+
+## Check Completion
+
+For each step in the current phase from `workflow-catalog.yaml`:
+
+- If the step has `artifact.glob`, check for matching files.
+- If it has `min_count`, verify the minimum count.
+- If it has `artifact.pattern`, check the pattern in matching files.
+- If it has `artifact.note`, mark it as manual/unknown and ask only if it
+  blocks the next recommendation.
+- Treat repeatable steps as "started" unless the catalog or project state
+  proves all required items are complete.
+
+For Production, prefer `production/sprint-status.yaml` over markdown scanning:
+
+- `in-progress`: current work.
+- `ready-for-dev`: next implementable story.
+- `blocked`: surface blocker.
+- `done`: completed.
+
+## Output Format
+
+Keep output short and decision-oriented:
+
+```text
+Where you are: [Phase]
+
+Done:
+- [confirmed completed item]
+
+Next required:
+[Step] - [why it matters]
+Ask Codex to: "[natural-language request]"
+
+Optional now:
+- [optional step]
+
+Coming up:
+- [next required step]
+```
+
+Use original `/command` names only as references, for example:
+`original workflow: /design-system`. Prefer natural-language Codex requests as
+the actionable instruction.
+
+If the user is confused, add the two escalation paths:
+
+- Full gap audit: ask Codex to detect the project stage and missing artifacts.
+- Phase gate: ask Codex to run a gate check for the current phase.
+
+## Constraints
+
+- Do not write files.
+- Do not advance phase state.
+- Do not run long test suites unless the user explicitly asks for verification.

--- a/.agents/skills/cgs-hotfix/SKILL.md
+++ b/.agents/skills/cgs-hotfix/SKILL.md
@@ -1,0 +1,119 @@
+---
+name: cgs-hotfix
+description: Use to run a Codex Game Studios emergency hotfix workflow for S1/S2 issues, including severity assessment, hotfix record creation, minimal fix discipline, targeted validation, approval tracking, rollback planning, and backport reminders. This is the Codex-native replacement for the original Claude Code `/hotfix` workflow.
+metadata:
+  short-description: Manage an emergency hotfix
+---
+
+# Codex Game Studios Hotfix
+
+This skill is for urgent S1/S2 production issues. It bypasses normal sprint
+flow only with an audit trail and a minimal, testable fix.
+
+## Severity Gate
+
+Classify the issue:
+
+- `S1 Critical`: game unplayable, data loss, security issue, broken launch.
+- `S2 Major`: significant feature broken with player impact; workaround exists.
+- `S3 or lower`: recommend normal bug triage instead of hotfix.
+
+If severity is unclear, ask for impact, affected version/platform, repro steps,
+and known workaround.
+
+## Inputs To Read
+
+- Bug report or user-provided incident description.
+- Current release/milestone docs under `production/`.
+- Existing hotfix records under `production/hotfixes/`.
+- Relevant source, tests, QA plans, smoke checks, and regression suites.
+- Git status and branch/tag context before branch or commit operations.
+- Original source workflow, only if more detail is needed:
+  `.claude/skills/hotfix/SKILL.md`.
+
+## Hotfix Record
+
+Draft:
+
+- short description.
+- date and affected version/platform.
+- severity and reporter/source.
+- player impact.
+- root cause placeholder.
+- minimal fix plan.
+- targeted validation plan.
+- approval checklist.
+- rollback plan.
+- backport targets.
+
+After approval or explicit write request, create `production/hotfixes/` and
+write `production/hotfixes/hotfix-[date]-[slug].md`.
+
+## Branch And Implementation
+
+Before changing code:
+
+- Check `git status --short --branch`.
+- Identify the release base or main branch/tag.
+- Create a hotfix branch only when the user authorizes it.
+- Keep the fix minimal. Do not refactor, clean up unrelated code, or add
+  features.
+- Add or update only tests that prove the fix and guard the adjacent regression.
+
+If the fix appears to exceed roughly four focused hours or touches core
+architecture, stop and recommend escalation before continuing.
+
+## Validation And Approvals
+
+Run the smallest useful validation set:
+
+- targeted automated tests for the affected area.
+- adjacent regression tests.
+- smoke check for the hotfix build when available.
+- manual repro verification when automation cannot cover it.
+
+Do not assume Claude named subagents exist. Track sign-offs in the hotfix
+record or use user-approved Codex delegation only when the user explicitly asks
+for parallel agent work.
+
+Required approvals:
+
+- technical review.
+- QA/regression verification.
+- release/producer approval.
+
+## Deployment Summary
+
+When ready, output:
+
+- severity.
+- root cause.
+- minimal fix.
+- validation performed.
+- approvals.
+- rollback plan.
+- branches/tags to merge into.
+- bug record update needed.
+
+Hotfixes must merge to both the release branch and development branch unless
+the project explicitly documents a different policy.
+
+## Post-Deploy
+
+After deployment:
+
+- verify the original repro against the deployed build.
+- update and close the bug only after verification.
+- schedule a post-incident review within 48 hours.
+- add regression coverage to the normal suite if the hotfix introduced only
+  temporary targeted coverage.
+
+## Completion
+
+Finish with:
+
+- hotfix record path if written.
+- branch name if created.
+- files changed.
+- validations run and result.
+- remaining approvals or deployment blockers.

--- a/.agents/skills/cgs-launch-checklist/SKILL.md
+++ b/.agents/skills/cgs-launch-checklist/SKILL.md
@@ -1,0 +1,95 @@
+---
+name: cgs-launch-checklist
+description: Use to generate a Codex Game Studios launch readiness checklist across code, content, QA, store, marketing, community, infrastructure, legal, operations, and go/no-go sign-offs. This is the Codex-native replacement for the original Claude Code `/launch-checklist` workflow.
+metadata:
+  short-description: Check launch readiness
+---
+
+# Codex Game Studios Launch Checklist
+
+This skill validates launch readiness across departments. It is broader than
+`cgs-release-checklist` and should be used near final launch or for launch
+dry-runs.
+
+## Modes
+
+- `launch date`: generate a checklist for a concrete launch date.
+- `dry-run`: generate the same analysis without writing files or creating
+  sign-off records.
+
+If the date or mode is missing, ask unless project docs make it unambiguous.
+
+## Inputs To Read
+
+- `AGENTS.md` and relevant project instructions.
+- Latest milestone under `production/milestones/`.
+- Existing release checklists under `production/releases/`.
+- `design/live-ops/content-calendar.md`, if present.
+- QA, regression, smoke, soak, and bug/risk records under `production/`.
+- Store, legal, community, and support docs, if present.
+- `.claude/docs/technical-preferences.md`.
+- Original source workflow, only if more detail is needed:
+  `.claude/skills/launch-checklist/SKILL.md`.
+
+## Scan For Launch Risks
+
+Search for:
+
+- `TODO`, `FIXME`, and `HACK`.
+- debug output such as `console.log`, `print()`, and temporary debug flags.
+- placeholder assets and names such as `placeholder`, `temp_`, and `WIP_`.
+- hardcoded test/dev values such as `localhost`, test credentials, or dev-only
+  feature flags.
+- missing launch evidence in QA, release, or milestone docs.
+
+## Checklist Sections
+
+Generate:
+
+- Code Readiness: build health, tests, performance, version/tag, crash
+  reporting, production flags.
+- Content Readiness: final assets, audio, localization, credits, complete game
+  flow, save/load, achievements.
+- QA: regression, zero critical blockers, soak/stress/edge-case testing,
+  certification, accessibility.
+- Store and Distribution: copy, screenshots, trailer, key art, pricing,
+  ratings, system requirements.
+- Legal: EULA, privacy, third-party licenses, music rights, trademark/IP,
+  regional compliance.
+- Infrastructure: servers, backups, CDN, monitoring, alerting, analytics.
+- Community and Marketing: guidelines, moderation, FAQ, known issues,
+  launch posts, press keys.
+- Operations: on-call, incident response, rollback, hotfix pipeline, launch
+  war room, day-one plan.
+- Go / No-Go Decision: `READY`, `CONDITIONAL`, or `NOT READY`.
+- Sign-Offs Required: creative, technical, QA, producer, release owner.
+
+## Output
+
+Present:
+
+- Target launch date or `DRY RUN`.
+- Department-by-department readiness.
+- Blocking items.
+- Conditional risks.
+- Missing evidence.
+- Full checklist.
+
+Do not treat unchecked or undocumented launch items as complete.
+
+## Write Output
+
+In `dry-run`, do not write unless explicitly requested.
+
+Otherwise, after approval or an explicit write request, create
+`production/releases/` and write
+`production/releases/launch-checklist-[date].md`.
+
+## Completion
+
+Finish with:
+
+- Checklist path if written.
+- Go/no-go decision.
+- Launch blockers.
+- Recommended next step: release checklist, gate check, or hotfix readiness.

--- a/.agents/skills/cgs-localize/SKILL.md
+++ b/.agents/skills/cgs-localize/SKILL.md
@@ -1,0 +1,87 @@
+---
+name: cgs-localize
+description: Use to run Codex Game Studios localization workflows including hardcoded string scan, extraction, validation, status, translator briefs, cultural review, VO pipeline, RTL check, string freeze, and localization QA. This is the Codex-native replacement for the original Claude Code `/localize` workflow.
+metadata:
+  short-description: Manage localization
+---
+
+# Codex Game Studios Localize
+
+This skill manages localization from string extraction through QA. It treats
+English (`en`) as the source locale unless the project documents otherwise.
+
+## Modes
+
+- `scan`: find hardcoded strings and localization anti-patterns.
+- `extract`: generate new string-table entries.
+- `validate`: check translations for completeness, placeholders, length, stale
+  entries, and encoding risks.
+- `status`: localization coverage matrix.
+- `brief`: translator context briefing.
+- `cultural-review`: cultural and sensitivity risk review.
+- `vo-pipeline`: scan, script, validate, or integrate localized VO.
+- `rtl-check`: right-to-left layout and font readiness.
+- `freeze`: call, check, or lift string freeze.
+- `qa`: localization QA plan and verdict.
+
+If no mode is provided, show the modes and ask which to run.
+
+## Inputs To Read
+
+- source and translation tables under `assets/data/strings/`.
+- UI/source files under `src/`.
+- narrative, lore, and GDD files under `design/`.
+- audio under `assets/audio/vo/`, for VO modes.
+- localization reports under `production/localization/`.
+- `.claude/docs/technical-preferences.md`.
+- Original source workflow, only if more detail is needed:
+  `.claude/skills/localize/SKILL.md`.
+
+## Core Rules
+
+- every string-table entry needs translator context.
+- prefer named placeholders over positional placeholders.
+- avoid string concatenation for localized sentences.
+- do not modify translation files directly; generate diffs or reports first.
+- call string freeze before sending text to translators.
+- RTL and cultural review are required for relevant commercial locales.
+
+## Mode Behavior
+
+Read-only by default:
+
+- `scan`, `validate`, `status`, `rtl-check`, and most QA checks report findings.
+
+Writes after approval:
+
+- `extract`: append new entries to source table.
+- `brief`: write `production/localization/translator-brief-[locale]-[date].md`.
+- `cultural-review`: write cultural review report.
+- `vo-pipeline script`: write VO scripts.
+- `freeze`: write or update freeze status.
+- `qa`: write localization QA report.
+
+Use Codex delegation only when the user explicitly asks for parallel agent work.
+
+## Reports
+
+Include:
+
+- mode and locale(s).
+- files scanned.
+- blocking findings.
+- advisory findings.
+- coverage or readiness summary.
+- exact files/keys affected.
+- next required action before release.
+
+## Completion
+
+Finish with:
+
+- mode result.
+- files written, if any.
+- blocking localization issues.
+- coverage or QA verdict when applicable.
+- next recommended Codex request: extract, validate, cultural review,
+  RTL check, VO pipeline, or release gate check.

--- a/.agents/skills/cgs-map-systems/SKILL.md
+++ b/.agents/skills/cgs-map-systems/SKILL.md
@@ -1,0 +1,120 @@
+---
+name: cgs-map-systems
+description: Use to decompose a Codex Game Studios game concept into systems, dependencies, priorities, and design order, creating or updating `design/gdd/systems-index.md`. This is the Codex-native replacement for the original Claude Code `/map-systems` workflow.
+metadata:
+  short-description: Map game systems and dependencies
+---
+
+# Codex Game Studios Map Systems
+
+This skill creates or updates the systems index. It turns the game concept into
+a dependency-ordered list of systems to design and implement.
+
+## Modes
+
+- Full map: no systems index exists or the user asks to map the project.
+- Next system: the user asks what system to design next.
+- Revision: a systems index exists and the user wants to add, split, combine, or
+  reprioritize systems.
+
+## Inputs To Read
+
+- `design/gdd/game-concept.md`; required for a full map.
+- `design/gdd/game-pillars.md`, if present.
+- `design/gdd/systems-index.md`, if present.
+- Existing `design/gdd/*.md` files to detect designed systems.
+- `.claude/docs/templates/systems-index.md` for the output shape.
+- Original source workflow, only if more detail is needed:
+  `.claude/skills/map-systems/SKILL.md`.
+
+If the concept is missing, stop and recommend running the concept brainstorm
+workflow first.
+
+## Enumerate Systems
+
+Extract explicit systems from:
+
+- Core mechanics.
+- Core loop.
+- MVP/scope sections.
+- Technical considerations.
+- UX, narrative, economy, progression, or content requirements.
+
+Infer implicit systems. Examples:
+
+- Combat implies health, damage, hit detection, enemy behavior, feedback, and
+  combat UI.
+- Crafting implies recipes, ingredients, item data, crafting UI, discovery, and
+  persistence.
+- Dialogue implies dialogue graph, UI, choice tracking, localization, and NPC
+  state.
+- Multiplayer implies networking, lobby, state sync, authority, security, and
+  network UX.
+
+Present systems by category with one-sentence descriptions and whether each was
+explicit or inferred. Ask the user to confirm missing, merged, split, or
+unwanted systems before writing.
+
+## Map Dependencies
+
+For each system, identify dependencies:
+
+- Input/output dependency: consumes data from another system.
+- Structural dependency: plugs into a foundation system.
+- UX dependency: interface depends on gameplay behavior.
+- Persistence dependency: save/load or state ownership.
+
+Assign each system to a layer:
+
+- Foundation
+- Core
+- Feature
+- Presentation
+- Polish
+
+Flag cycles and propose a resolution: interface contract, split ownership, or
+temporary provisional dependency.
+
+## Assign Priority
+
+Assign tiers:
+
+- MVP: required for the smallest playable core loop.
+- Vertical Slice: needed for a representative complete experience.
+- Alpha: broader content and system coverage.
+- Full Vision: optional expansion, polish, meta, or post-launch systems.
+
+Explain priority with player-experience reasoning, not only technical
+dependency.
+
+## Write Output
+
+Before editing, summarize:
+
+- Total system count.
+- MVP count.
+- First 3 systems in design order.
+- High-risk or bottleneck systems.
+- Dependency cycles or provisional assumptions.
+
+Ask whether to write `design/gdd/systems-index.md`. After approval, create or
+update the file using the systems-index template. Preserve existing progress
+statuses where possible.
+
+## Next-System Mode
+
+If asked for the next system:
+
+1. Read `design/gdd/systems-index.md`.
+2. Find the highest-priority undesigned system whose required dependencies are
+   designed or can be explicitly treated as provisional.
+3. Report the recommended system and why.
+4. Recommend asking Codex to design that system with the `cgs-design-system`
+   workflow.
+
+## Completion
+
+Finish with:
+
+- The systems index path written or updated, or the next system recommendation.
+- The next recommended Codex request.

--- a/.agents/skills/cgs-milestone-review/SKILL.md
+++ b/.agents/skills/cgs-milestone-review/SKILL.md
@@ -1,0 +1,87 @@
+---
+name: cgs-milestone-review
+description: Use to generate a Codex Game Studios milestone progress review with feature completeness, quality metrics, code health, risk assessment, velocity, scope recommendations, and a go/no-go recommendation. This is the Codex-native replacement for the original Claude Code `/milestone-review` workflow.
+metadata:
+  short-description: Review milestone readiness
+---
+
+# Codex Game Studios Milestone Review
+
+This skill reviews whether a milestone is on track and what scope or quality
+risks must be addressed before the deadline.
+
+## Scope And Mode
+
+Accept a milestone name or `current`. If missing, use the most recently modified
+file under `production/milestones/` when unambiguous; otherwise ask.
+
+Review modes:
+
+- `solo`: no delegated review; produce the review directly.
+- `lean`: default; produce the review without director gate simulation.
+- `full`: include a producer-style risk assessment, but only use Codex
+  delegation if the user explicitly asks for parallel agent work.
+
+Read `production/review-mode.txt` if mode is not specified.
+
+## Inputs To Read
+
+- Milestone definition under `production/milestones/`.
+- Sprint plans, sprint status, and retrospectives under `production/sprints/`
+  and `production/retrospectives/`.
+- QA plans, bug reports, smoke/regression results, and release records under
+  `production/`.
+- Risk register under `production/risk-register/`, if present.
+- GDDs and architecture docs referenced by milestone scope.
+- Git history for the milestone period, if available.
+- Original source workflow, only if more detail is needed:
+  `.claude/skills/milestone-review/SKILL.md`.
+
+## Analyze
+
+Assess:
+
+- feature completeness: complete, partial, not started.
+- acceptance criteria and test evidence status.
+- open S1/S2/S3 bugs and release-blocking risks.
+- TODO/FIXME/HACK counts and notable locations.
+- risk register status and mitigations.
+- planned vs completed work across milestone sprints.
+- velocity trend and adjusted estimate for remaining work.
+- cut candidates that preserve milestone intent.
+
+Do not report a `GO` recommendation if critical evidence is missing or high
+severity blockers remain unassigned.
+
+## Review Output
+
+Generate:
+
+- Overview: target date, current date, days remaining, sprints complete.
+- Feature Completeness tables.
+- Quality Metrics.
+- Code Health.
+- Risk Assessment.
+- Velocity Analysis.
+- Scope Recommendations: Protect, At Risk, Cut Candidates.
+- Go/No-Go: `GO`, `CONDITIONAL GO`, or `NO-GO`.
+- Action Items with owner/deadline when known.
+
+For `full` mode, add a `Producer Risk Assessment` section. If no delegated
+producer review is available, label it as Codex-inferred.
+
+## Write Output
+
+Show the review and top risks first. After approval or explicit write request,
+create `production/milestones/` and write
+`production/milestones/[milestone-name]-review.md`.
+
+## Completion
+
+Finish with:
+
+- review path if written.
+- go/no-go recommendation.
+- top blockers.
+- suggested next Codex request: sprint plan, gate check, bug triage, or scope
+  reduction.

--- a/.agents/skills/cgs-onboard/SKILL.md
+++ b/.agents/skills/cgs-onboard/SKILL.md
@@ -1,0 +1,81 @@
+---
+name: cgs-onboard
+description: Use to generate a Codex Game Studios onboarding document for a new contributor, role, or project area by summarizing project state, architecture, standards, current priorities, key files, dependencies, pitfalls, and first tasks. This is the Codex-native replacement for the original Claude Code `/onboard` workflow.
+metadata:
+  short-description: Create onboarding docs
+---
+
+# Codex Game Studios Onboard
+
+This skill creates a contextual onboarding document for a role or area. It is
+for contributors joining the project, not first-time project setup.
+
+## Scope
+
+Accept a role or area, such as:
+
+- programmer.
+- designer.
+- narrative.
+- QA.
+- production.
+- audio.
+- UI.
+- a specific system or directory.
+
+If missing, ask who or what area the onboarding doc is for.
+
+## Inputs To Read
+
+- `AGENTS.md` and relevant directory `AGENTS.md`.
+- relevant role references under `.claude/agents/`, if present.
+- `README.md` and `docs/CODEX-PORTING.md`.
+- `design/`, `docs/`, `src/`, `tests/`, and `production/` subsets relevant
+  to the role.
+- latest sprint, milestone, and git history, if available.
+- Original source workflow, only if more detail is needed:
+  `.claude/skills/onboard/SKILL.md`.
+
+## Scan By Role
+
+- Programmers: architecture, source layout, coding standards, tests.
+- Designers: concepts, systems, GDDs, art/UX specs.
+- Narrative: narrative docs, characters, dialogue, localization risks.
+- QA: test assets, QA plans, bug workflow, regression suite.
+- Production: sprint, milestone, risk, release, onboarding state.
+- Area-specific: read the target directory and related docs.
+
+## Document
+
+Generate:
+
+- Project Summary.
+- Your Role.
+- Project Architecture or domain overview.
+- Key Directories.
+- Key Files with read priority.
+- Current Standards and Conventions.
+- Current State of Your Area.
+- Current Sprint Context.
+- Key Dependencies.
+- Common Pitfalls.
+- First Tasks.
+- Questions to Ask.
+
+Keep the output practical and role-specific. Do not dump the whole repository.
+
+## Write Output
+
+Present the onboarding doc first. After approval or explicit write request,
+create `production/onboarding/` and write
+`production/onboarding/onboard-[role]-[date].md`.
+
+## Completion
+
+Finish with:
+
+- onboarding path if written.
+- intended role or area.
+- first three recommended reads.
+- first safe task.
+- next recommended Codex request: sprint status, help, or role-specific review.

--- a/.agents/skills/cgs-patch-notes/SKILL.md
+++ b/.agents/skills/cgs-patch-notes/SKILL.md
@@ -1,0 +1,91 @@
+---
+name: cgs-patch-notes
+description: Use to generate Codex Game Studios player-facing patch notes from internal changelogs, release records, git history, sprint context, balance docs, and QA records, with brief, detailed, or full style output. This is the Codex-native replacement for the original Claude Code `/patch-notes` workflow.
+metadata:
+  short-description: Write player patch notes
+---
+
+# Codex Game Studios Patch Notes
+
+This skill produces public patch notes. It should not expose internal file
+paths, sprint numbers, ticket IDs, developer names, or implementation jargon.
+
+## Scope And Style
+
+- Version is required. If missing, ask.
+- Styles: `brief`, `detailed`, or `full`.
+- Default style: `detailed`.
+
+Use `brief` for short announcements, `detailed` for normal releases, and `full`
+when developer commentary is requested.
+
+## Inputs To Read
+
+- `production/releases/[version]/changelog.md`, if present.
+- `docs/CHANGELOG.md`, if it contains the version.
+- Git history between previous release tag and target version/HEAD.
+- Sprint retrospectives under `production/sprints/`.
+- Balance docs under `design/balance/`, if present.
+- QA bug fix and known issue records, if present.
+- Tone/style guidance from `.claude/docs/technical-preferences.md`,
+  `docs/PATCH-NOTES-STYLE.md`, or `design/community/tone-guide.md`.
+- Patch note template from `docs/patch-notes-template.md` or
+  `.claude/docs/templates/patch-notes-template.md`, if present.
+- Original source workflow, only if more detail is needed:
+  `.claude/skills/patch-notes/SKILL.md`.
+
+If no changelog, release record, or usable git history exists, stop with
+`BLOCKED` and recommend generating a changelog first.
+
+## Categorize For Players
+
+Use:
+
+- New Content
+- Gameplay Changes
+- Quality of Life
+- Bug Fixes
+- Performance
+- Known Issues
+
+Translate developer language into player-visible outcomes. Preserve useful
+numbers for balance changes, but avoid implementation details.
+
+## Output Styles
+
+- `brief`: compact bullets for new content, changes, fixes, and known issues.
+- `detailed`: highlights, sections, balance table, grouped fixes, known
+  issues, and workarounds.
+- `full`: detailed output plus developer commentary in a team voice.
+
+If a template exists, use the template structure instead of the built-in
+sections while preserving the same evidence and privacy rules.
+
+## Review Before Writing
+
+Check:
+
+- no internal jargon or references.
+- bug fixes describe player symptoms.
+- balance changes include before/after values when available.
+- tone matches the project guidance.
+- known issues are accurate and not overpromised.
+- internal-only changes are excluded or reframed.
+
+## Write Output
+
+Show the patch notes, category counts, and excluded internal changes first.
+
+After approval or an explicit write request, create directories and write:
+
+- `docs/patch-notes/[version].md`
+- `production/releases/[version]/patch-notes.md`
+
+## Completion
+
+Finish with:
+
+- Patch notes status: generated, written, or blocked.
+- File paths if written.
+- Source data used.
+- Items needing community/producer review before publishing.

--- a/.agents/skills/cgs-perf-profile/SKILL.md
+++ b/.agents/skills/cgs-perf-profile/SKILL.md
@@ -1,0 +1,73 @@
+---
+name: cgs-perf-profile
+description: Use to run a Codex Game Studios performance profiling analysis for one system or the full project, identifying budgets, static hotspots, runtime profiling needs, optimization priorities, quick wins, and scope/timeline trade-offs. This is the Codex-native replacement for the original Claude Code `/perf-profile` workflow.
+metadata:
+  short-description: Analyze performance risk
+---
+
+# Codex Game Studios Performance Profile
+
+This skill identifies performance risks and optimization candidates. Static
+analysis can find suspects; runtime profiling on target hardware is required to
+confirm impact.
+
+## Scope
+
+- system name: focus on one system.
+- `full`: profile all systems at a high level.
+
+If scope is missing, ask whether to analyze one system or the whole project.
+
+## Inputs To Read
+
+- `.claude/docs/technical-preferences.md`.
+- Performance budgets in GDDs, technical docs, release docs, or engine
+  preferences.
+- Relevant source files for the target system.
+- Existing performance tests, profiler captures, logs, or benchmarks.
+- Engine reference docs under `docs/engine-reference/`, if present.
+- Original source workflow, only if more detail is needed:
+  `.claude/skills/perf-profile/SKILL.md`.
+
+Do not assume a named performance subagent exists. Use Codex delegation only
+when the user explicitly asks for parallel agent work.
+
+## Analyze Hotspots
+
+Look for:
+
+- per-frame code such as `_process`, `Update`, `Tick`, timers, and loops.
+- nested loops over entities or large collections.
+- allocations, string work, sorting, searching, or logging in hot paths.
+- frequent physics queries.
+- instantiate/destroy patterns that should use pooling.
+- large data structures, caches, and missing eviction.
+- sync asset loading or save/load blocking paths.
+- rendering risks: draw calls, overdraw, shader complexity, particles, LODs.
+- networking frequency, packet size, and validation overhead if applicable.
+
+## Report
+
+Generate:
+
+- Performance Budgets table: frame time, memory, load time, draw calls,
+  network as applicable.
+- Hotspots Identified table with location, issue, estimated impact, fix effort.
+- Optimization Recommendations in priority order.
+- Quick Wins under one hour.
+- Requires Runtime Profiling: areas that need measurement before action.
+- Scope and Timeline Decision: implement, reduce scope, defer, or consider ADR
+  for medium/large fixes.
+
+Classify estimated impact and fix effort conservatively when evidence is weak.
+
+## Completion
+
+Finish with:
+
+- top 3 hotspots.
+- estimated headroom vs budget when known.
+- quick wins.
+- measurement gaps.
+- next recommended Codex request: targeted profiling, ADR, scope check, or
+  sprint plan update.

--- a/.agents/skills/cgs-playtest-report/SKILL.md
+++ b/.agents/skills/cgs-playtest-report/SKILL.md
@@ -1,0 +1,89 @@
+---
+name: cgs-playtest-report
+description: Use to create or analyze Codex Game Studios playtest reports, structure raw notes, categorize findings into design, balance, bugs, and polish, and route follow-up work. This is the Codex-native replacement for the original Claude Code `/playtest-report` workflow.
+metadata:
+  short-description: Structure playtest feedback
+---
+
+# Codex Game Studios Playtest Report
+
+This skill standardizes playtest evidence and turns raw observations into
+actionable follow-up work.
+
+## Modes And Review
+
+- `new`: create a blank playtest report template.
+- `analyze [path]`: turn raw notes into a structured report.
+
+Review modes:
+
+- `solo`: no delegated player-experience review.
+- `lean`: default; no director gate.
+- `full`: include a creative-director-style assessment, but use Codex
+  delegation only if the user explicitly asks for parallel agent work.
+
+Read `production/review-mode.txt` if review mode is not specified.
+
+## Inputs To Read
+
+- Raw playtest notes for analyze mode.
+- `design/gdd/game-concept.md` for pillars and core fantasy.
+- Relevant GDDs for tested systems.
+- QA bug reports and known issues, if relevant.
+- Balance docs, if relevant.
+- Original source workflow, only if more detail is needed:
+  `.claude/skills/playtest-report/SKILL.md`.
+
+## Report Template
+
+Generate or fill:
+
+- Session Info: date, build, duration, tester, platform, input method, session
+  type.
+- Test Focus.
+- First Impressions: goal understanding, controls, emotional response, notes.
+- Gameplay Flow: worked well, pain points, confusion, delight.
+- Bugs Encountered table.
+- Feature-Specific Feedback.
+- Quantitative Data if available.
+- Overall Assessment.
+- Top 3 Priorities.
+
+For analyze mode, label observations that conflict with design intent.
+
+## Action Routing
+
+Categorize findings:
+
+- Design changes needed: fun issues, confusion, mechanics not matching intent.
+- Balance adjustments: difficulty, pacing, economy, numbers, spikes.
+- Bug reports: reproducible implementation defects.
+- Polish items: friction or feel issues that are not immediate blockers.
+
+Route follow-up:
+
+- Design changes: review downstream impact before changing GDDs.
+- Balance adjustments: run balance analysis before tuning.
+- Bugs: file structured bug reports.
+- Polish: add to a polish backlog when appropriate.
+
+## Full Review Mode
+
+For `full`, add a `Player Experience Assessment` section using game pillars,
+core fantasy, and the playtest hypothesis. Mark it as Codex-inferred unless the
+user explicitly requested delegated review.
+
+## Write Output
+
+Show the report, categorized findings, and top three priorities first. After
+approval or explicit write request, create `production/qa/playtests/` and write
+`production/qa/playtests/playtest-[date]-[tester].md`.
+
+## Completion
+
+Finish with:
+
+- report path if written.
+- top three priorities.
+- bug reports that should be filed.
+- design/balance/polish follow-up recommendations.

--- a/.agents/skills/cgs-propagate-design-change/SKILL.md
+++ b/.agents/skills/cgs-propagate-design-change/SKILL.md
@@ -1,0 +1,84 @@
+---
+name: cgs-propagate-design-change
+description: Use when a Codex Game Studios GDD has changed and architecture or ADR traceability may be stale, producing a design change impact report, affected ADR classifications, traceability updates, and follow-up ADR actions. This is the Codex-native replacement for the original Claude Code `/propagate-design-change` workflow.
+metadata:
+  short-description: Propagate GDD changes
+---
+
+# Codex Game Studios Propagate Design Change
+
+This skill finds architecture decisions that may be stale after a GDD revision.
+
+## Required Input
+
+A changed GDD path is required. If missing or invalid, ask for the path and stop
+until it is provided.
+
+## Inputs To Read
+
+- current changed GDD.
+- previous committed version from git, if available.
+- ADRs under `docs/architecture/`.
+- `docs/architecture/architecture-traceability.md`, if present.
+- Original source workflow, only if more detail is needed:
+  `.claude/skills/propagate-design-change/SKILL.md`.
+
+If there is no previous git version, report that this appears to be a new GDD
+and that there may be nothing to propagate.
+
+## Analyze GDD Changes
+
+Compare previous vs current GDD and summarize:
+
+- changed sections.
+- unchanged sections.
+- new, removed, or modified rules.
+- formula changes.
+- tuning knob changes.
+- acceptance criteria changes.
+- changes likely to affect architecture.
+
+## ADR Impact Analysis
+
+For each ADR referencing the changed GDD:
+
+- locate referenced requirements in the current GDD.
+- compare what the ADR assumed against what the GDD now says.
+- classify as `Still Valid`, `Needs Review`, or `Likely Superseded`.
+- recommend `Keep as-is`, `Review and update`, or `Mark Superseded and write
+  new ADR`.
+
+Use Codex delegation only if the user explicitly asks for parallel review.
+
+## Report
+
+Generate:
+
+- Design Change Impact Report.
+- change summary.
+- ADRs not affected.
+- ADRs needing review.
+- likely superseded ADRs.
+- recommended resolution per ADR.
+- traceability index update needs.
+
+## Writes
+
+Ask before every write.
+
+Allowed writes after approval:
+
+- mark ADR status as superseded or pending replacement.
+- update `docs/architecture/architecture-traceability.md`.
+- write `docs/architecture/change-impact-[date]-[system-slug].md`.
+
+Never delete ADR content.
+
+## Completion
+
+Finish with:
+
+- affected ADR counts.
+- change impact report path if written.
+- ADRs needing replacement or update.
+- next recommended Codex request: architecture decision or architecture review.

--- a/.agents/skills/cgs-prototype/SKILL.md
+++ b/.agents/skills/cgs-prototype/SKILL.md
@@ -1,0 +1,95 @@
+---
+name: cgs-prototype
+description: Use to run a Codex Game Studios rapid prototype workflow for a game concept or mechanic, defining the core question, planning minimal throwaway implementation, isolating prototype code under `prototypes/`, and producing a PROCEED/PIVOT/KILL report. This is the Codex-native replacement for the original Claude Code `/prototype` workflow.
+metadata:
+  short-description: Run a rapid prototype
+---
+
+# Codex Game Studios Prototype
+
+This skill validates a game idea quickly with throwaway code and a structured
+report. Prototype code is never production code.
+
+## Define The Question
+
+Read the concept description and identify one core question the prototype must
+answer. If the question is vague, ask for clarification before planning.
+
+Review modes:
+
+- `solo`: no delegated review.
+- `lean`: default; report with Codex's recommendation.
+- `full`: include creative-director-style assessment, but only use Codex
+  delegation if the user explicitly asks for parallel agent work.
+
+Read `production/review-mode.txt` if review mode is not specified.
+
+## Inputs To Read
+
+- `AGENTS.md` and `.claude/docs/technical-preferences.md`.
+- `design/gdd/game-concept.md`, if present.
+- Related GDDs, quick specs, or prior prototypes.
+- Original source workflow, only if more detail is needed:
+  `.claude/skills/prototype/SKILL.md`.
+
+## Plan
+
+Present a 3-5 bullet prototype plan:
+
+- core question.
+- minimum playable/testable slice.
+- what is deliberately skipped.
+- rough timebox.
+- evidence to collect.
+
+Ask for confirmation if scope is unclear or expanding.
+
+## Implementation Rules
+
+After approval or explicit request, create `prototypes/[concept-name]/`.
+
+Every prototype source file should start with:
+
+```text
+PROTOTYPE - NOT FOR PRODUCTION
+Question: [core question]
+Date: [date]
+```
+
+Rules:
+
+- hardcode values freely.
+- use placeholders.
+- skip production architecture and polish.
+- avoid importing production source.
+- production code must never import prototype files.
+- if proceeding, rewrite production implementation from scratch.
+
+## Report
+
+Generate `prototypes/[concept-name]/REPORT.md` with:
+
+- Hypothesis.
+- Approach.
+- Result.
+- Metrics.
+- Recommendation: `PROCEED`, `PIVOT`, or `KILL`.
+- If Proceeding: production architecture, performance, scope, and estimate
+  implications.
+- If Pivoting or Killing: rationale and alternative direction.
+- Lessons Learned.
+
+## Write Output
+
+Show the report first. After approval or explicit write request, write
+`prototypes/[concept-name]/REPORT.md`.
+
+## Completion
+
+Finish with:
+
+- core question.
+- report path if written.
+- recommendation.
+- next recommended Codex request: design system, ADR, revised prototype, or
+  playtest report.

--- a/.agents/skills/cgs-qa-plan/SKILL.md
+++ b/.agents/skills/cgs-qa-plan/SKILL.md
@@ -1,0 +1,75 @@
+---
+name: cgs-qa-plan
+description: Use to generate a Codex Game Studios QA plan for a sprint, feature, epic, or story by classifying stories, mapping automated and manual evidence, defining smoke scope, and documenting story-level test requirements. This is the Codex-native replacement for the original Claude Code `/qa-plan` workflow.
+metadata:
+  short-description: Create a QA test plan
+---
+
+# Codex Game Studios QA Plan
+
+This skill creates `production/qa/qa-plan-[scope]-[date].md`. Run it before
+implementation begins so developers know what evidence each story needs.
+
+## Scope
+
+- `sprint`: current sprint stories.
+- `feature: [system]`: stories for a system/feature.
+- `story: [path]`: one story.
+- `epic: [slug]`: all stories in one epic.
+
+If scope is missing, infer only when unambiguous; otherwise ask.
+
+## Inputs To Read
+
+- `production/sprint-status.yaml` and latest `production/sprints/*.md`.
+- `production/epics/**/*.md` stories and `EPIC.md` files.
+- Referenced GDD Acceptance Criteria and Formulas sections.
+- `design/gdd/systems-index.md`.
+- `docs/architecture/control-manifest.md`, if present.
+- `.claude/docs/technical-preferences.md`.
+- Original source workflow, only if more detail is needed:
+  `.claude/skills/qa-plan/SKILL.md`.
+
+## Classify Stories
+
+Use existing `Type:` when present; otherwise infer:
+
+- Logic: calculations, rules, state transitions, AI decisions.
+- Integration: two or more systems, save/load, events, network sync.
+- Visual/Feel: animation, VFX, audio sync, responsiveness, subjective feel.
+- UI: screens, menus, HUD, controls, accessibility.
+- Config/Data: balance/config file changes only.
+
+Mixed stories get the highest-risk type and a note.
+
+## Plan Contents
+
+Generate:
+
+- Test Summary table.
+- Automated Tests Required with suggested paths.
+- Manual QA Checklist.
+- Smoke Test Scope.
+- Playtest Requirements.
+- Definition of Done for the scope.
+- Gaps: missing GDD, missing story type, unclear acceptance criteria, missing
+  evidence path.
+
+Do not invent requirements beyond story ACs and GDD formulas. If information is
+missing, flag it.
+
+## Write Output
+
+Show summary first. After approval, create `production/qa/` and write the QA
+plan. Do not truncate generated plan content.
+
+## Completion
+
+Finish with:
+
+- QA plan path.
+- Stories covered.
+- Required automated tests.
+- Manual evidence requirements.
+- Next recommended Codex request: smoke check after implementation or story
+  readiness before implementation.

--- a/.agents/skills/cgs-quick-design/SKILL.md
+++ b/.agents/skills/cgs-quick-design/SKILL.md
@@ -1,0 +1,80 @@
+---
+name: cgs-quick-design
+description: Use to create a lightweight Codex Game Studios quick design spec for small tuning, tweak, addition, or new-small-system changes that do not need a full GDD, including context scan, design delta, acceptance criteria, and GDD update guidance. This is the Codex-native replacement for the original Claude Code `/quick-design` workflow.
+metadata:
+  short-description: Draft a quick design spec
+---
+
+# Codex Game Studios Quick Design
+
+This skill is the lightweight design path for changes too small for a full GDD
+but too meaningful to implement without written rationale.
+
+## Classification
+
+Classify the requested change:
+
+- `Tuning`: value/balance changes with no behavioral change.
+- `Tweak`: small behavior change in an existing system.
+- `Addition`: small mechanic added to an existing system.
+- `New Small System`: standalone feature small enough to avoid full GDD.
+
+Redirect to `cgs-design-system` if the change adds significant cross-system
+dependencies, alters core contracts, changes the game's aesthetic balance, or
+is likely to exceed roughly one week of implementation.
+
+If classification is uncertain, ask before drafting.
+
+## Inputs To Read
+
+- Relevant GDD under `design/gdd/`.
+- `design/gdd/systems-index.md`, if present.
+- Prior quick specs under `design/quick-specs/`.
+- Relevant data files under `assets/data/` for tuning changes.
+- Original source workflow, only if more detail is needed:
+  `.claude/skills/quick-design/SKILL.md`.
+
+## Draft The Spec
+
+For `Tuning`, include:
+
+- changed parameter table with old value, new value, and rationale.
+- mapping to the GDD tuning knob and allowed range.
+- acceptance criteria proving values are data-driven and observable.
+
+For `Tweak` or `Addition`, include:
+
+- change summary and motivation.
+- design delta from the current GDD rule.
+- precise new rules, states, values, and edge conditions.
+- affected systems table.
+- acceptance criteria and regression criterion.
+- whether a GDD update is required.
+
+For `New Small System`, include:
+
+- scope boundary.
+- overview.
+- core rules.
+- tuning knobs with defaults/ranges.
+- acceptance criteria.
+- systems-index recommendation.
+
+## Write Output
+
+Present the draft in full. After approval or explicit write request, create
+`design/quick-specs/` and write
+`design/quick-specs/[kebab-title]-[date].md`.
+
+If a GDD update is required, show the exact proposed old/new text and ask
+before editing the GDD.
+
+## Completion
+
+Finish with:
+
+- quick spec path if written.
+- type and system.
+- GDD update status.
+- next recommended Codex request: story readiness, dev story, or full design
+  system if scope has grown.

--- a/.agents/skills/cgs-regression-suite/SKILL.md
+++ b/.agents/skills/cgs-regression-suite/SKILL.md
@@ -1,0 +1,68 @@
+---
+name: cgs-regression-suite
+description: Use to audit or update the Codex Game Studios regression suite by mapping GDD critical paths and fixed bugs to existing tests, identifying missing regression coverage, and maintaining `tests/regression-suite.md`. This is the Codex-native replacement for the original Claude Code `/regression-suite` workflow.
+metadata:
+  short-description: Maintain regression coverage
+---
+
+# Codex Game Studios Regression Suite
+
+This skill maintains `tests/regression-suite.md`, a curated index of tests that
+must always pass to protect critical paths and fixed bugs.
+
+## Modes
+
+- `update`: check current sprint/fixed bugs and add new regression entries.
+- `audit`: full GDD critical-path coverage audit.
+- `report`: read-only status report.
+
+## Inputs To Read
+
+- `tests/regression-suite.md`, if present.
+- Test inventory under `tests/unit/`, `tests/integration/`, and
+  `tests/regression/`.
+- `design/gdd/systems-index.md` and MVP system GDDs for audit mode.
+- Current sprint plan and stories for update mode.
+- Closed/fixed bug files under `production/qa/bugs/`.
+- Original source workflow, only if more detail is needed:
+  `.claude/skills/regression-suite/SKILL.md`.
+
+## Checks
+
+- Map GDD acceptance criteria, formulas, and edge cases to test files.
+- Map closed bugs to tests that would catch the original failure.
+- Detect coverage drift from completed stories without tests.
+- Flag stale or quarantined tests.
+
+Coverage statuses:
+
+- Covered.
+- Partial.
+- Missing.
+- Exempt for visual/UI/manual-only criteria.
+
+## Write Output
+
+For `report`, do not write.
+
+For `update`, append new entries and gaps; do not remove existing tests without
+explicit approval.
+
+For `audit`, ask before rewriting the manifest.
+
+Manifest sections:
+
+- How to run.
+- Registered Regression Tests.
+- Known Gaps.
+- Quarantined Tests.
+- Coverage summary.
+
+## Completion
+
+Finish with:
+
+- Coverage rate.
+- Bug fixes without regression tests.
+- High-priority missing tests.
+- Manifest path if written.

--- a/.agents/skills/cgs-release-checklist/SKILL.md
+++ b/.agents/skills/cgs-release-checklist/SKILL.md
@@ -1,0 +1,93 @@
+---
+name: cgs-release-checklist
+description: Use to generate a Codex Game Studios pre-release validation checklist for PC, console, mobile, or all target platforms, including code health, build verification, QA gates, store metadata, launch readiness, blockers, and sign-offs. This is the Codex-native replacement for the original Claude Code `/release-checklist` workflow.
+metadata:
+  short-description: Build a release checklist
+---
+
+# Codex Game Studios Release Checklist
+
+This skill creates a pre-release checklist for a version or target platform. It
+does not certify a release by itself; it makes release blockers explicit.
+
+## Scope
+
+- `pc`: PC distribution checks.
+- `console`: console certification and platform behavior checks.
+- `mobile`: mobile store and device checks.
+- `all`: all relevant platform sections.
+
+Default to `all` if platform scope is not specified. If version is missing,
+infer from milestone/release docs when obvious; otherwise ask.
+
+## Inputs To Read
+
+- `AGENTS.md` and relevant project instructions.
+- Latest milestone under `production/milestones/`, if present.
+- Existing files under `production/releases/`, if present.
+- QA plans, smoke checks, regression results, and test logs, if present.
+- Open bug/risk documents under `production/`, if present.
+- `.claude/docs/technical-preferences.md`.
+- Original source workflow, only if more detail is needed:
+  `.claude/skills/release-checklist/SKILL.md`.
+
+## Scan For Blockers
+
+Use repository search to count and sample:
+
+- `TODO`
+- `FIXME`
+- `HACK`
+- placeholder or WIP content markers
+- known critical/major bugs
+- missing or stale QA evidence
+
+Treat `FIXME`, critical bugs, failed tests, and missing release evidence as
+potential blockers unless project docs explicitly accept the risk.
+
+## Checklist Sections
+
+Generate:
+
+- Codebase Health: TODO/FIXME/HACK counts and top locations.
+- Build Verification: clean builds, warnings, versioning, included assets,
+  reproducibility.
+- Quality Gates: critical bug status, regression, performance, soak, smoke,
+  and QA sign-off.
+- Content Complete: placeholders, player-facing text, localization readiness,
+  audio, credits, licenses.
+- Platform Requirements: PC, console, and/or mobile requirements based on
+  scope.
+- Store / Distribution: metadata, screenshots, trailers, ratings, pricing,
+  legal, third-party attribution.
+- Launch Readiness: telemetry, crash reporting, day-one patch, on-call,
+  support, rollback.
+- Go / No-Go: `READY`, `CONDITIONAL`, or `NOT READY` with rationale.
+- Sign-Offs Required: QA, technical, production, creative, and release owner.
+
+## Output
+
+Present:
+
+- Version/platform.
+- Total checklist items.
+- Known blockers.
+- Conditional risks.
+- Go/no-go recommendation.
+- Full checklist.
+
+Do not mark uncertain items as complete. Use `[ ]` until evidence exists.
+
+## Write Output
+
+After approval or an explicit write request, create `production/releases/` and
+write `production/releases/release-checklist-[version].md`.
+
+## Completion
+
+Finish with:
+
+- Checklist path if written.
+- Go/no-go recommendation.
+- Blocking items to resolve first.
+- Next recommended Codex request: gate check, launch checklist, or patch notes.

--- a/.agents/skills/cgs-retrospective/SKILL.md
+++ b/.agents/skills/cgs-retrospective/SKILL.md
@@ -1,0 +1,101 @@
+---
+name: cgs-retrospective
+description: Use to generate or update a Codex Game Studios sprint or milestone retrospective from plans, status, git history, bugs, blockers, velocity, previous action items, and technical debt trends. This is the Codex-native replacement for the original Claude Code `/retrospective` workflow.
+metadata:
+  short-description: Create a retrospective
+---
+
+# Codex Game Studios Retrospective
+
+This skill converts sprint or milestone outcomes into actionable process
+improvements for the next iteration.
+
+## Scope
+
+Accept:
+
+- `sprint-N`: sprint retrospective.
+- milestone name: milestone retrospective.
+
+If missing, infer from the latest sprint or milestone only when unambiguous;
+otherwise ask.
+
+## Existing Retrospective
+
+Before drafting, look for:
+
+- `production/retrospectives/retro-[slug]-*.md`.
+- `production/sprints/sprint-[N]-retrospective.md`.
+- milestone retrospective files under `production/retrospectives/`.
+
+If one exists, summarize it and ask whether to update it or create a fresh
+retrospective. Do not silently overwrite.
+
+## Inputs To Read
+
+- Sprint or milestone plan.
+- `production/sprint-status.yaml`, if present.
+- Sprint reports, QA plans, bug reports, and playtest reports.
+- Previous retrospectives and action items.
+- Git history for the covered period, if available.
+- TODO/FIXME/HACK counts and previous counts if recorded.
+- Original source workflow, only if more detail is needed:
+  `.claude/skills/retrospective/SKILL.md`.
+
+If the sprint or milestone source data is missing, ask the user to provide the
+period, goals, planned work, and outcomes, or stop as blocked.
+
+## Analyze
+
+Compare plan vs actual:
+
+- completed as planned.
+- completed with scope changes.
+- carried over.
+- added mid-iteration.
+- removed or descoped.
+- blockers and time lost.
+- estimation accuracy and repeated under/over-estimates.
+- previous action items completed or ignored.
+- technical debt trend.
+
+Focus on system/process causes, not blame.
+
+## Retrospective Output
+
+Generate:
+
+- Metrics table: planned/actual tasks, effort, bugs, unplanned work, commits.
+- Velocity Trend.
+- What Went Well.
+- What Went Poorly.
+- Blockers Encountered.
+- Estimation Accuracy.
+- Carryover Analysis.
+- Technical Debt Status.
+- Previous Action Items Follow-Up.
+- Action Items for Next Iteration.
+- Process Improvements.
+- Summary.
+
+Limit action items to 3-5, each specific enough to execute.
+
+## Write Output
+
+Present the retrospective and the top findings first. After approval or
+explicit write request, write to:
+
+- `production/sprints/sprint-[N]-retrospective.md` for sprint retros.
+- `production/retrospectives/retro-[milestone-name]-[date].md` for milestone
+  retros.
+
+Create directories as needed.
+
+## Completion
+
+Finish with:
+
+- retrospective path if written.
+- completion rate and velocity trend.
+- most important blocker.
+- action items for the next sprint or phase.

--- a/.agents/skills/cgs-reverse-document/SKILL.md
+++ b/.agents/skills/cgs-reverse-document/SKILL.md
@@ -1,0 +1,91 @@
+---
+name: cgs-reverse-document
+description: Use to generate Codex Game Studios design, architecture, or concept documentation from existing implementation or prototypes, separating observed behavior from clarified intent and writing reverse-documented files only after approval. This is the Codex-native replacement for the original Claude Code `/reverse-document` workflow.
+metadata:
+  short-description: Document existing implementation
+---
+
+# Codex Game Studios Reverse Document
+
+This skill works backwards from code or prototypes to produce missing planning
+documents. It must not infer intent without asking.
+
+## Modes
+
+Use:
+
+- `design [path]`: generate a system GDD from gameplay/UI implementation.
+- `architecture [path]`: generate an ADR or architecture note from core code.
+- `concept [path]`: generate a concept document from a prototype.
+
+If type or path is missing, ask for both.
+
+## Inputs To Read
+
+- target file or directory.
+- relevant existing GDDs, ADRs, quick specs, and prototypes.
+- `.claude/docs/technical-preferences.md`.
+- templates if present under `templates/`.
+- Original source workflow, only if more detail is needed:
+  `.claude/skills/reverse-document/SKILL.md`.
+
+## Analyze Implementation
+
+For design docs, identify:
+
+- mechanics, rules, formulas, gameplay values.
+- states and edge cases handled in code.
+- dependencies and system interactions.
+
+For architecture docs, identify:
+
+- patterns, dependencies, coupling, technical decisions.
+- constraints, tradeoffs, performance characteristics.
+
+For concepts, identify:
+
+- core mechanic, player fantasy, emergent patterns.
+- what worked, what failed, and feasibility notes.
+
+## Clarify Intent
+
+Before drafting, show findings and ask about unclear intent:
+
+- why a resource exists.
+- whether a mechanic is core or supporting.
+- whether a scaling behavior is intentional.
+- whether an architecture pattern is deliberate or legacy.
+
+Separate observed behavior from user-confirmed intent.
+
+## Draft
+
+Draft the appropriate document with:
+
+- current behavior.
+- clarified intent.
+- missing or partial areas.
+- risks and follow-up work.
+- reverse-documentation metadata.
+
+Use `status: reverse-documented`, source path, date, and verification note in
+the document header when writing.
+
+## Write Output
+
+Show the draft first. After approval or explicit write request, write to the
+appropriate location:
+
+- `design/gdd/[system-name].md`
+- `docs/architecture/[decision-name].md`
+- `prototypes/[name]/CONCEPT.md` or `design/concepts/[name].md`
+
+## Completion
+
+Finish with:
+
+- output path if written.
+- intent areas confirmed.
+- incomplete sections.
+- recommended follow-up: balance check, ADR, design review, or implementation
+  cleanup.

--- a/.agents/skills/cgs-review-all-gdds/SKILL.md
+++ b/.agents/skills/cgs-review-all-gdds/SKILL.md
@@ -1,0 +1,93 @@
+---
+name: cgs-review-all-gdds
+description: Use to run a holistic Codex Game Studios cross-GDD review across all system GDDs, checking consistency, dependency symmetry, rule contradictions, ownership conflicts, formula compatibility, design holism, progression loops, attention budget, economy, pillar alignment, and scenario failures. This is the Codex-native replacement for the original Claude Code `/review-all-gdds` workflow.
+metadata:
+  short-description: Review all GDDs
+---
+
+# Codex Game Studios Review All GDDs
+
+This skill reviews relationships between GDDs. Use it after MVP-tier GDDs are
+written and before architecture begins.
+
+## Modes
+
+- `full`: consistency plus design holism.
+- `consistency`: cross-document consistency only.
+- `design-theory`: design holism only.
+- `since-last-review`: only GDDs changed since the last cross-review.
+
+Default to `full`.
+
+## Inputs To Read
+
+- `design/gdd/game-concept.md`.
+- `design/gdd/game-pillars.md`, if present.
+- `design/gdd/systems-index.md`.
+- all in-scope system GDDs under `design/gdd/`.
+- `design/registry/entities.yaml`, if present.
+- latest `design/gdd/gdd-cross-review-*.md`, for incremental mode.
+- Original source workflow, only if more detail is needed:
+  `.claude/skills/review-all-gdds/SKILL.md`.
+
+If fewer than two system GDDs exist, stop and recommend writing more GDDs first.
+
+## Consistency Review
+
+Check:
+
+- dependency bidirectionality.
+- rule contradictions.
+- stale cross-document references.
+- data and tuning knob ownership conflicts.
+- formula output/input range compatibility.
+- acceptance criteria contradictions.
+- registry conflicts or stale entries.
+
+Every issue must cite the GDD, section, and conflicting text or value.
+
+## Design Holism Review
+
+Check:
+
+- competing progression loops.
+- player attention budget and cognitive overload.
+- dominant strategies.
+- economic loops, sources, sinks, and runaway feedback.
+- difficulty curve consistency.
+- pillar and anti-pillar alignment.
+- player fantasy coherence.
+- 3-5 key cross-system scenario walkthroughs.
+
+Do not decide which GDD is correct. Surface options and required decisions.
+
+## Report
+
+Generate:
+
+- GDDs reviewed and systems covered.
+- Consistency Issues: blocking and warnings.
+- Game Design Issues: blocking and warnings.
+- Cross-System Scenario Issues.
+- GDDs Flagged for Revision.
+- Verdict: `PASS`, `CONCERNS`, or `FAIL`.
+- Required actions if `FAIL`.
+
+## Write Output
+
+Present the report first. After approval or explicit write request, write
+`design/gdd/gdd-cross-review-[date].md`.
+
+If GDDs need revision, ask separately before updating
+`design/gdd/systems-index.md` statuses to `Needs Revision`.
+
+## Completion
+
+Finish with:
+
+- verdict.
+- report path if written.
+- blocking issue count.
+- GDDs needing revision.
+- next recommended Codex request: design review, consistency check, gate check,
+  or create architecture.

--- a/.agents/skills/cgs-scope-check/SKILL.md
+++ b/.agents/skills/cgs-scope-check/SKILL.md
@@ -1,0 +1,74 @@
+---
+name: cgs-scope-check
+description: Use to run a read-only Codex Game Studios scope creep review for a feature, sprint, or milestone by comparing the original plan to current implementation, additions, removals, bloat score, risks, and cut/defer recommendations. This is the Codex-native replacement for the original Claude Code `/scope-check` workflow.
+metadata:
+  short-description: Check scope creep
+---
+
+# Codex Game Studios Scope Check
+
+This skill is read-only. It compares original planned scope against the current
+state and reports whether scope has drifted.
+
+## Scope
+
+Accept a feature name, sprint number, or milestone name. If missing, ask for the
+baseline scope to compare.
+
+## Inputs To Read
+
+- Feature baseline: matching `design/gdd/*.md` or `design/**/*.md`.
+- Sprint baseline: matching `production/sprints/*.md`.
+- Milestone baseline: matching `production/milestones/*.md`.
+- Current sprint status and related epics/stories.
+- Git history and changed files for the relevant date range, if available.
+- TODO/FIXME/HACK markers related to the scope.
+- Original source workflow, only if more detail is needed:
+  `.claude/skills/scope-check/SKILL.md`.
+
+If no baseline plan exists, stop and report that scope cannot be measured.
+
+## Compare
+
+Extract:
+
+- original scope items.
+- current implemented or in-progress items.
+- additions not present in the original plan.
+- removals or descopes.
+- changes that are justified discovered requirements.
+- changes that need producer or creative decision.
+
+Scope creep means additions without matching cuts, timeline extension, or
+explicit acceptance.
+
+## Report
+
+Generate:
+
+- Original Scope.
+- Current Scope.
+- Scope Additions table: addition, source, when, justification, effort.
+- Scope Removals table: removed item, reason, impact.
+- Bloat Score: original items, current items, added %, removed, net change.
+- Risk Assessment: schedule, quality, integration.
+- Recommendations: cut, defer, keep, flag.
+
+Verdict:
+
+- `PASS`: net change <= 10%.
+- `CONCERNS`: net change > 10% and <= 25%.
+- `FAIL`: net change > 25%.
+
+If the item count is misleading, keep the verdict but add a qualitative risk
+note.
+
+## Completion
+
+Finish with:
+
+- scope verdict.
+- net change.
+- top 2-3 cut/defer candidates.
+- next recommended Codex request: sprint plan update, estimate, or re-run after
+  cuts.

--- a/.agents/skills/cgs-security-audit/SKILL.md
+++ b/.agents/skills/cgs-security-audit/SKILL.md
@@ -1,0 +1,96 @@
+---
+name: cgs-security-audit
+description: Use to audit Codex Game Studios security risks across save files, serialization, networking, input validation, data exposure, cheat vectors, and dependencies, producing prioritized findings and release recommendations. This is the Codex-native replacement for the original Claude Code `/security-audit` workflow.
+metadata:
+  short-description: Audit security risk
+---
+
+# Codex Game Studios Security Audit
+
+This skill audits common game security failure modes. It is not a replacement
+for a human penetration test for competitive, monetized, or multiplayer games.
+
+## Scope
+
+- `full`: all categories; default before release.
+- `network`: multiplayer/network only.
+- `save`: save file and serialization only.
+- `input`: input validation only.
+- `quick`: high-severity checks only.
+
+If no scope is provided, use `full`.
+
+## Inputs To Read
+
+- `.claude/docs/technical-preferences.md` for engine, language, platforms, and
+  multiplayer scope.
+- Source directories, config files, `assets/data/`, plugins, addons, and
+  third-party/vendor folders.
+- Release docs, QA bug reports, and prior security audits, if present.
+- Original source workflow, only if more detail is needed:
+  `.claude/skills/security-audit/SKILL.md`.
+
+Do not assume a named security subagent exists. Use Codex delegation only when
+the user explicitly asks for parallel agent work.
+
+## Audit Categories
+
+Check applicable categories:
+
+- Save and serialization: blind deserialization, path traversal, missing bounds
+  checks, missing tamper detection, dynamic code execution near load paths.
+- Network and multiplayer: client authority, packet size/type/range validation,
+  rate limiting, token handling, release debug endpoints.
+- Input validation: user-controlled paths, log injection, numeric bounds,
+  backend achievement/stat writes.
+- Data exposure: secrets, tokens, verbose release logs, sensitive player data,
+  internal file paths.
+- Cheat and anti-tamper: editable progression values, leaderboard validation,
+  DLC/entitlement trust, multiplayer server authority.
+- Dependencies: plugins, addons, third-party libraries, source, version, known
+  risk notes when available.
+
+## Classify Findings
+
+Severity:
+
+- `CRITICAL`: remote code execution, data breach, or trivially exploitable
+  multiplayer integrity break.
+- `HIGH`: save tampering bypass, credential exposure, server authority bypass.
+- `MEDIUM`: limited input validation, client-side cheat enablement,
+  information disclosure.
+- `LOW`: defense-in-depth hardening.
+
+Status: `Open`, `Accepted Risk`, or `Out of Scope`.
+
+For multiplayer, treat HIGH integrity findings as release blockers.
+
+## Report
+
+Generate:
+
+- Executive Summary by severity.
+- Release recommendation: `CLEAR TO SHIP`, `FIX CRITICALS FIRST`, or
+  `DO NOT SHIP`.
+- CRITICAL/HIGH/MEDIUM/LOW findings with category, file/line, description,
+  attack scenario, remediation, and effort.
+- Accepted Risk.
+- Dependency Inventory.
+- Remediation Priority Order.
+- Re-audit trigger.
+
+## Write Output
+
+Present executive summary and CRITICAL/HIGH findings first. After approval or
+explicit write request, create `production/security/` and write
+`production/security/security-audit-[date].md`.
+
+## Completion
+
+Finish with:
+
+- audit status and path if written.
+- blocking findings.
+- release recommendation.
+- next recommended Codex request: remediate, quick re-audit, gate check, or
+  launch checklist.

--- a/.agents/skills/cgs-setup-engine/SKILL.md
+++ b/.agents/skills/cgs-setup-engine/SKILL.md
@@ -1,0 +1,138 @@
+---
+name: cgs-setup-engine
+description: Use to configure the game engine, language, platform targets, input methods, performance defaults, testing approach, and engine-specialist routing for Codex Game Studios. This is the Codex-native replacement for the original Claude Code `/setup-engine` workflow.
+metadata:
+  short-description: Configure game engine and project standards
+---
+
+# Codex Game Studios Setup Engine
+
+This skill configures engine-specific project standards for Codex Game Studios.
+It replaces Claude Code-specific behavior with Codex-readable files and explicit
+edits.
+
+## Supported Modes
+
+Recognize these user intents:
+
+- Full spec: "configure Godot 4.6" or "setup Unity 6".
+- Engine only: "configure Unity"; verify the current stable version from
+  official sources before writing.
+- Guided: no engine chosen; recommend an engine based on concept and
+  constraints.
+- Refresh: update engine reference docs.
+- Upgrade: migrate settings from one engine version to another.
+
+When current/latest engine versions matter, verify from official release docs or
+official engine websites before relying on memory.
+
+## Files To Read
+
+- `AGENTS.md`: Codex project-level instructions.
+- `.claude/docs/technical-preferences.md`: current preferences file until a
+  Codex-native equivalent exists.
+- `design/gdd/game-concept.md`: genre, scope, platform, art style, and any
+  engine recommendation.
+- `docs/engine-reference/<engine>/VERSION.md`: pinned version if already set.
+- Original source workflow, only if needed:
+  `.claude/skills/setup-engine/SKILL.md`.
+
+## Guided Recommendation
+
+If no engine is chosen, gather only the missing critical facts:
+
+- Prior engine experience.
+- Target platform: PC, mobile, console, web, or multiple.
+- Game shape: 2D, 3D, both, open-world, photorealistic, stylized, etc.
+- Primary input: keyboard/mouse, gamepad, touch, mixed.
+- Team size and experience.
+- Language preference.
+- Licensing constraints.
+
+Use these practical defaults:
+
+- Godot: strongest for 2D, solo/small teams, fast iteration, open source,
+  contained stylized 3D.
+- Unity: strongest for mobile, mid-scope 3D, console-oriented indie work,
+  asset-store-heavy development, C# teams.
+- Unreal: strongest for high-end 3D, open-world, photorealism, Blueprint-heavy
+  prototyping, PC/console visual fidelity.
+
+Present one primary recommendation and one alternative. The user chooses; do not
+force a verdict.
+
+## Language Selection
+
+For Godot, ask whether the project primarily uses:
+
+- GDScript: fastest native iteration.
+- C#: stronger IDE/tooling, useful for C# experience or heavier logic.
+- Both: advanced mixed setup.
+
+Unity defaults to C#.
+
+Unreal defaults to C++ plus Blueprint for gameplay prototyping.
+
+## Edits To Make
+
+Show a concise proposed changeset before editing. After confirmation, update:
+
+- `AGENTS.md` Technology Stack section.
+- `.claude/docs/technical-preferences.md` until a Codex-native preferences file
+  is introduced.
+- `docs/engine-reference/<engine>/VERSION.md` if pinning or upgrading the
+  engine version.
+
+Do not edit `CLAUDE.md` unless the user wants to keep Claude Code compatibility
+updated too.
+
+## Technical Preferences Content
+
+Populate:
+
+- Engine and language.
+- Rendering and physics stack when known.
+- Target platforms and input methods.
+- Naming conventions.
+- Performance budgets if the user accepts defaults.
+- Testing framework recommendation.
+- Engine specialist routing, translated as Codex role guidance rather than
+  guaranteed named subagents.
+
+Do not add speculative dependencies. Add a library or addon only when the
+project is actively integrating it.
+
+## Safe Defaults
+
+If the user accepts defaults:
+
+- Target framerate: 60 FPS.
+- Frame budget: 16.6 ms.
+- Gamepad support:
+  - PC only: Partial recommended.
+  - Console: Full.
+  - Mobile: None.
+  - PC + Console: Full.
+  - PC + Mobile: Partial.
+  - Web: Partial.
+- Touch support:
+  - Mobile: Full.
+  - PC + Mobile: Full.
+  - Web: Partial.
+  - Otherwise: None.
+
+Testing defaults:
+
+- Godot: GUT or engine-native test harness, depending on language choice.
+- Unity: Unity Test Framework/NUnit.
+- Unreal: Unreal Automation Testing Framework.
+
+## Verification
+
+After editing:
+
+- Re-read modified sections.
+- Confirm placeholders were replaced only where intended.
+- If JSON or shell files were touched, run relevant syntax checks.
+- Report any version information that could not be verified from official
+  sources.

--- a/.agents/skills/cgs-smoke-check/SKILL.md
+++ b/.agents/skills/cgs-smoke-check/SKILL.md
@@ -1,0 +1,79 @@
+---
+name: cgs-smoke-check
+description: Use to run or document a Codex Game Studios smoke check before QA handoff, combining automated test status, core-path manual verification, coverage warnings, platform checks, and a PASS/FAIL report. This is the Codex-native replacement for the original Claude Code `/smoke-check` workflow.
+metadata:
+  short-description: Run smoke readiness gate
+---
+
+# Codex Game Studios Smoke Check
+
+This skill gates "implementation complete" to "ready for QA handoff". A failed
+smoke check means the build is not ready for manual QA.
+
+## Modes
+
+- `sprint`: full smoke check for current sprint.
+- `quick`: skip broad coverage scan; use for re-checks.
+- Platform variants: pc, console, mobile, all.
+
+## Inputs To Read
+
+- `.claude/docs/technical-preferences.md` for engine/platform.
+- `tests/` structure and relevant test results.
+- Latest `production/qa/qa-plan-*.md`.
+- `production/qa/smoke-tests.md` or `tests/smoke/`, if present.
+- Latest sprint plan and `production/sprint-status.yaml`.
+- Original source workflow, only if more detail is needed:
+  `.claude/skills/smoke-check/SKILL.md`.
+
+## Automated Checks
+
+- Detect test framework and CI workflow.
+- Run scoped automated tests only when the command is known and safe in the
+  current environment.
+- If engine binary or runner is unavailable, record `NOT RUN` with reason rather
+  than treating it as automatic failure.
+- Parse pass/fail counts when available.
+
+## Coverage And Manual Checks
+
+- Compare sprint stories to expected test/evidence files from QA plan.
+- Flag Logic/Integration stories missing test files.
+- Verify core stability manually:
+  - Launches to main menu.
+  - New game/session starts.
+  - Main menu responds to input.
+  - Sprint's primary mechanic works.
+  - Previous sprint features show no obvious regressions.
+  - Save/load and performance checked when applicable.
+- Add platform-specific batches when requested.
+
+## Verdicts
+
+- `PASS`: automated tests pass or are manually confirmed, core checks pass, no
+  critical gaps.
+- `PASS WITH WARNINGS`: tests not run locally, minor evidence gaps, or advisory
+  coverage drift.
+- `FAIL`: crash, failed core path, failing automated tests, or critical mechanic
+  broken.
+
+## Write Output
+
+After summarizing, ask before writing `production/qa/smoke-[date].md`.
+
+Report:
+
+- Environment.
+- Automated test results.
+- Coverage gaps.
+- Manual smoke responses.
+- Platform results.
+- Verdict and blockers.
+
+## Completion
+
+Finish with:
+
+- Smoke report path if written.
+- QA handoff readiness.
+- Required fixes before QA, if any.

--- a/.agents/skills/cgs-sprint-plan/SKILL.md
+++ b/.agents/skills/cgs-sprint-plan/SKILL.md
@@ -1,0 +1,101 @@
+---
+name: cgs-sprint-plan
+description: Use to create, update, or summarize a Codex Game Studios sprint plan from epics, stories, milestones, capacity, carryover, and risks. This is the Codex-native replacement for the original Claude Code `/sprint-plan` workflow.
+metadata:
+  short-description: Plan or update a sprint
+---
+
+# Codex Game Studios Sprint Plan
+
+This skill creates or updates `production/sprints/sprint-[N].md` and optionally
+`production/sprint-status.yaml`.
+
+## Modes
+
+- `new`: create the next sprint.
+- `update`: update the current sprint while preserving story status.
+- `status`: produce a read-only sprint status summary.
+
+## Inputs To Read
+
+- `production/milestones/`, if present.
+- Existing `production/sprints/`.
+- `production/sprint-status.yaml`, if present.
+- `production/epics/**/*.md`.
+- Story readiness results, if available in docs or session state.
+- `production/risk-register/`, if present.
+- QA plan files under `production/qa/`, if present.
+- Original source workflow, only if more detail is needed:
+  `.claude/skills/sprint-plan/SKILL.md`.
+
+## Build A Sprint
+
+For a new sprint:
+
+- Determine sprint number and dates.
+- Define one sprint goal.
+- Estimate capacity and reserve 20% buffer.
+- Select stories by priority and dependency readiness.
+- Separate Must Have, Should Have, and Nice to Have.
+- Carry over unfinished prior sprint work with reason.
+- List risks, mitigations, and external dependencies.
+- Include a sprint Definition of Done.
+
+Do not overfill capacity. If estimates exceed available capacity, recommend
+de-scoping before writing.
+
+## Sprint Status YAML
+
+When writing a sprint plan, also offer to write
+`production/sprint-status.yaml`.
+
+Use statuses:
+
+- backlog
+- ready-for-dev
+- in-progress
+- review
+- done
+- blocked
+
+For updates, preserve existing statuses unless the story was removed or the user
+explicitly changes it.
+
+## QA Plan Gate
+
+Check whether a sprint QA plan exists. If missing, warn that implementation can
+start but Production to Polish readiness will be blocked until QA planning and
+signoff exist.
+
+## Output
+
+For `new` or `update`, present the draft before writing:
+
+- Sprint goal.
+- Capacity.
+- Must Have stories.
+- Should Have stories.
+- Nice to Have stories.
+- Carryover.
+- Risks.
+- QA plan status.
+
+After approval, write files.
+
+For `status`, do not write. Report:
+
+- Completed.
+- In progress.
+- Blocked.
+- Not started.
+- Burndown assessment.
+- Emerging risks.
+
+## Completion
+
+Finish with:
+
+- Sprint file path if written.
+- Sprint status YAML path if written.
+- QA plan status.
+- First ready story recommendation.

--- a/.agents/skills/cgs-start/SKILL.md
+++ b/.agents/skills/cgs-start/SKILL.md
@@ -1,0 +1,92 @@
+---
+name: cgs-start
+description: Use for first-time onboarding in Codex Game Studios when the user wants to start a new game project, re-orient a fresh fork, choose where to begin, or replace the original Claude Code `/start` workflow with a Codex-native onboarding flow.
+metadata:
+  short-description: Start Codex Game Studios onboarding
+---
+
+# Codex Game Studios Start
+
+This is the Codex-native replacement for the original `.claude/skills/start`
+workflow. It orients the user and recommends the next workflow without assuming
+Claude Code slash commands or `AskUserQuestion`.
+
+## Inspect Project State
+
+Before recommending a path, check:
+
+- Engine configured: read `.claude/docs/technical-preferences.md`; placeholder
+  `[TO BE CONFIGURED]` means unset.
+- Game concept: `design/gdd/game-concept.md`.
+- Source code: source files in `src/` such as `*.gd`, `*.cs`, `*.cpp`, `*.h`,
+  `*.rs`, `*.py`, `*.js`, `*.ts`.
+- Prototypes: subdirectories under `prototypes/`.
+- Design docs: markdown files under `design/gdd/`.
+- Production artifacts: files under `production/sprints/` or
+  `production/milestones/`.
+- Review mode: `production/review-mode.txt`.
+
+Use `rg --files` and focused reads. Do not perform broad rewrites.
+
+## Classify Starting Point
+
+If the user has not already stated their situation, ask one concise question:
+
+```text
+Where are you starting from: no idea yet, vague idea, clear concept, or existing work?
+```
+
+Map the answer:
+
+- `no idea yet`: recommend brainstorming from open creative discovery.
+- `vague idea`: ask for a few words of theme, genre, or feeling, then recommend
+  concept brainstorming from that seed.
+- `clear concept`: ask for a one-sentence pitch, then recommend either
+  formalizing it first or setting up the engine.
+- `existing work`: report what the repository contains, then recommend a gap
+  audit and adoption/retrofit flow.
+
+If local evidence contradicts the answer, state the mismatch directly and ask
+for confirmation before routing.
+
+## Review Mode
+
+If `production/review-mode.txt` exists, preserve it.
+
+If missing, ask the user to choose:
+
+- `full`: director-style review at key workflow steps.
+- `lean`: review mainly at phase gates; default for solo/small teams.
+- `solo`: fastest path with minimal formal review.
+
+Only write `production/review-mode.txt` after the user chooses. Create
+`production/` if needed.
+
+## Recommend Next Workflow
+
+Do not assume `/command` invocation. Phrase handoffs as natural Codex requests:
+
+- Brainstorm: "Ask Codex to brainstorm the game concept."
+- Setup engine: "Ask Codex to configure the game engine."
+- Map systems: "Ask Codex to map the game systems."
+- Existing work: "Ask Codex to detect the project stage and migration gaps."
+
+Recommended paths:
+
+- Fresh/no idea: brainstorm concept, configure engine, define art bible, map
+  systems, author system GDDs, cross-review GDDs, then gate check.
+- Vague idea: brainstorm with the seed, then same as fresh path.
+- Clear concept: formalize concept or configure engine, then art bible, systems
+  map, GDDs, architecture, UX, prototype, epics, stories, sprint.
+- Existing work: detect project stage, audit artifact format, configure engine
+  if needed, retrofit GDDs/ADRs/stories, then gate check.
+
+Keep the response short. The output is a routing decision, not a full report.
+
+## Completion
+
+The start workflow is complete when the user has:
+
+- A classified starting point.
+- A review mode selected or confirmed.
+- One concrete next Codex request.

--- a/.agents/skills/cgs-story-done/SKILL.md
+++ b/.agents/skills/cgs-story-done/SKILL.md
@@ -1,0 +1,108 @@
+---
+name: cgs-story-done
+description: Use to verify and close a Codex Game Studios story after implementation by checking acceptance criteria, tests or manual evidence, GDD/ADR deviations, scope, and next ready work. This is the Codex-native replacement for the original Claude Code `/story-done` workflow.
+metadata:
+  short-description: Verify and close a story
+---
+
+# Codex Game Studios Story Done
+
+This skill verifies whether an implemented story can be marked complete. It does
+not implement missing work; use `cgs-dev-story` first.
+
+## Find The Story
+
+If a story path is provided, read it.
+
+If not:
+
+- Check `production/session-state/active.md`.
+- Check sprint or epic files for in-progress stories.
+- Ask the user to provide the story path if ambiguous.
+
+## Inputs To Read
+
+- Story file.
+- Referenced TR IDs from `docs/architecture/tr-registry.yaml`.
+- Referenced GDD sections.
+- Referenced ADR decision and consequences.
+- `docs/architecture/control-manifest.md`, if present.
+- Implementation files mentioned by story, session state, or recent git diff.
+- Test evidence paths from the story.
+- Original source workflow, only if more detail is needed:
+  `.claude/skills/story-done/SKILL.md`.
+
+## Verify Acceptance Criteria
+
+For each acceptance criterion:
+
+- Check implementation file existence.
+- Check tests or evidence files.
+- Run relevant tests when the command is known and scoped.
+- For subjective or build-only checks, ask for manual confirmation or mark
+  deferred with a clear reason.
+
+Create a traceability table:
+
+- Criterion.
+- Evidence: unit test, integration test, manual evidence, or deferred.
+- Status: covered, untested, failed, or not applicable.
+
+## Evidence Requirements
+
+- Logic: unit test exists and passes.
+- Integration: integration test or documented playtest/evidence exists.
+- Visual/Feel: manual evidence/signoff is advisory unless project policy says
+  otherwise.
+- UI: manual walkthrough, screenshot, or interaction test is advisory unless
+  project policy says otherwise.
+- Config/Data: smoke check evidence is advisory.
+
+Blocking gaps prevent completion.
+
+## Deviation Checks
+
+Compare implementation against:
+
+- Current TR requirement text.
+- GDD rules and formulas.
+- ADR decision and forbidden patterns.
+- Control manifest rules.
+- Story out-of-scope boundaries.
+
+Categorize findings:
+
+- Blocking: contradicts GDD/ADR, missing required tests, or fails AC.
+- Advisory: acceptable risk if documented.
+- Out of scope: extra touched files or behavior outside story.
+
+## Output Before Writes
+
+Present:
+
+- Verdict: Complete, Needs Fixes, or Blocked.
+- Acceptance criteria coverage.
+- Test results.
+- Deviations.
+- Manual confirmations needed.
+
+## Optional Writes
+
+Only after user approval and only if verdict is Complete or accepted with
+explicit advisory risks:
+
+- Update story `Status:` to `Complete`.
+- Add completion notes with date, evidence, and deviations.
+- Update `production/session-state/active.md`.
+- Update sprint or epic status if the file format is clear.
+
+Do not mark the story complete if blocking gaps remain.
+
+## Completion
+
+Finish with:
+
+- Story status.
+- Evidence summary.
+- Remaining risks.
+- Next ready story, if discoverable from epic or sprint files.

--- a/.agents/skills/cgs-story-readiness/SKILL.md
+++ b/.agents/skills/cgs-story-readiness/SKILL.md
@@ -1,0 +1,73 @@
+---
+name: cgs-story-readiness
+description: Use to validate whether one or more Codex Game Studios story files are ready for implementation, checking GDD traceability, ADR status, manifest version, dependencies, acceptance criteria, scope, and test evidence requirements. This is the Codex-native replacement for the original Claude Code `/story-readiness` workflow.
+metadata:
+  short-description: Check story implementation readiness
+---
+
+# Codex Game Studios Story Readiness
+
+This skill is read-only. It reports whether stories are ready to implement.
+
+## Scope
+
+- One story path.
+- `sprint`: stories in the current sprint.
+- `all`: all stories under `production/epics/`.
+- One epic directory.
+
+## Inputs To Read
+
+- Story files in scope.
+- `design/gdd/systems-index.md`.
+- `docs/architecture/control-manifest.md`.
+- `docs/architecture/tr-registry.yaml`.
+- Referenced ADR files.
+- Current sprint file, if checking sprint scope.
+- Original source workflow, only if more detail is needed:
+  `.claude/skills/story-readiness/SKILL.md`.
+
+## Checklist
+
+For each story:
+
+- GDD path and specific requirement or TR-ID referenced.
+- Acceptance criteria are self-contained and testable.
+- ADR reference exists, or explicit "No ADR applies" rationale exists.
+- Referenced ADR status is Accepted; Proposed ADRs block implementation.
+- TR-ID exists and is active when registry exists.
+- Manifest Version matches current control manifest when both exist.
+- Engine notes are present or N/A.
+- Scope and out-of-scope boundary are clear.
+- Dependencies are listed as files/IDs or explicitly None.
+- Dependency stories exist and are not Draft.
+- No unresolved TODO/TBD/UNRESOLVED markers in critical sections.
+- Referenced assets exist.
+- Story Type is declared.
+- Test Evidence section points to automated test or manual evidence path.
+
+## Verdicts
+
+- `READY`: all checks pass or have explicit N/A.
+- `NEEDS WORK`: fixable gaps, no blocking dependency/ADR issue.
+- `BLOCKED`: missing dependency, missing ADR, Proposed ADR, unresolved critical
+  question, or story depends on Draft work.
+
+## Output
+
+For one story:
+
+- Verdict.
+- Passing checks count.
+- Gaps with exact fixes.
+- Blockers.
+
+For multiple stories:
+
+- Counts by verdict.
+- Ready story list.
+- Needs work summary.
+- Blocked summary.
+- Detail for non-ready stories.
+
+Do not edit story files unless the user asks for a follow-up fix.

--- a/.agents/skills/cgs-tech-debt/SKILL.md
+++ b/.agents/skills/cgs-tech-debt/SKILL.md
@@ -1,0 +1,112 @@
+---
+name: cgs-tech-debt
+description: Use to scan, add, prioritize, or report Codex Game Studios technical debt by categorizing debt indicators, maintaining `docs/tech-debt-register.md`, scoring priority, and recommending repayment scheduling. This is the Codex-native replacement for the original Claude Code `/tech-debt` workflow.
+metadata:
+  short-description: Track technical debt
+---
+
+# Codex Game Studios Tech Debt
+
+This skill tracks conscious technical debt decisions and helps schedule
+repayment.
+
+## Modes
+
+- `scan`: scan the codebase for debt indicators.
+- `add`: add a manual debt entry.
+- `prioritize`: re-score and re-order the debt register.
+- `report`: summarize the current debt state.
+
+If no mode is provided, show usage and ask which mode to run.
+
+## Inputs To Read
+
+- Existing `docs/tech-debt-register.md`, if present.
+- Source, tests, docs, config, and build files relevant to the chosen mode.
+- Sprint plans and retrospectives for age/trend context.
+- Original source workflow, only if more detail is needed:
+  `.claude/skills/tech-debt/SKILL.md`.
+
+## Scan Mode
+
+Search for:
+
+- `TODO`, `FIXME`, `HACK`, and `@deprecated`.
+- large files or likely god objects.
+- long functions.
+- duplicated patterns.
+- missing tests around risky code.
+- outdated docs or undocumented public APIs.
+- deprecated or risky dependencies.
+- known slow paths.
+
+Categorize:
+
+- Architecture Debt.
+- Code Quality Debt.
+- Test Debt.
+- Documentation Debt.
+- Dependency Debt.
+- Performance Debt.
+
+Treat `FIXME` as likely bug debt and recommend bug reports for severe cases.
+
+## Add Mode
+
+Collect or infer:
+
+- description.
+- category.
+- affected files.
+- accepted reason.
+- estimated fix effort: S/M/L/XL.
+- impact if left unfixed.
+- suggested sprint or backlog.
+
+Every entry must explain why the debt is acceptable for now.
+
+## Prioritize Mode
+
+Read the register and score each item by:
+
+`(impact_if_unfixed * frequency_of_encounter) / fix_effort`
+
+Use the score as a recommendation, not an automatic mandate. Flag items older
+than three sprints for explicit fix or accepted-risk review.
+
+## Report Mode
+
+Generate read-only summary:
+
+- total items by category.
+- total estimated fix effort.
+- added vs resolved since last report when known.
+- trend: growing, stable, or shrinking.
+- aged items older than three sprints.
+- recommended next sprint candidates.
+
+## Write Output
+
+For `scan`, `add`, and `prioritize`, present the proposed register changes
+first. After approval or explicit write request, create or update
+`docs/tech-debt-register.md`.
+
+For `report`, do not write unless explicitly requested.
+
+## Register Format
+
+Use:
+
+| ID | Category | Description | Files | Effort | Impact | Priority | Added | Sprint |
+| --- | --- | --- | --- | --- | --- | --- | --- | --- |
+
+## Completion
+
+Finish with:
+
+- mode result.
+- register path if written.
+- highest priority debt.
+- aged debt requiring a decision.
+- next recommended Codex request: sprint plan, bug report, perf profile, or
+  architecture decision.

--- a/.agents/skills/cgs-test-helpers/SKILL.md
+++ b/.agents/skills/cgs-test-helpers/SKILL.md
@@ -1,0 +1,57 @@
+---
+name: cgs-test-helpers
+description: Use to create Codex Game Studios test helper libraries for the configured engine and systems, including assertion utilities, factories, mocks, and scene/test setup helpers. This is the Codex-native replacement for the original Claude Code `/test-helpers` workflow.
+metadata:
+  short-description: Generate test helper utilities
+---
+
+# Codex Game Studios Test Helpers
+
+This skill creates `tests/helpers/` utilities that reduce boilerplate in
+gameplay, integration, and UI tests.
+
+## Modes
+
+- `scaffold`: base helper library only.
+- `[system-name]`: helpers for one system.
+- `all`: helpers for systems with existing tests.
+
+## Inputs To Read
+
+- `.claude/docs/technical-preferences.md`.
+- Existing `tests/**/*_test.*` samples.
+- `design/gdd/systems-index.md`.
+- In-scope GDDs.
+- `docs/architecture/tr-registry.yaml`, if present.
+- Original source workflow, only if more detail is needed:
+  `.claude/skills/test-helpers/SKILL.md`.
+
+Stop if engine is not configured unless the user requests generic helpers.
+
+## Helper Types
+
+Generate only helpers that match the project:
+
+- Assertions for formula bounds, state, events/signals, and components.
+- Factories for minimal test objects, entities, resources, or data configs.
+- Mocks/stubs for dependencies.
+- Scene or integration test setup utilities.
+- Manual evidence templates when UI/Visual stories dominate.
+
+Do not invent project-specific APIs that do not exist. If source code is absent,
+create conservative placeholders and TODOs.
+
+## Write Output
+
+Before writing, show proposed helper files. After approval, create
+`tests/helpers/` and missing helper files. Do not overwrite existing helpers
+without explicit approval.
+
+## Completion
+
+Finish with:
+
+- Helper files created.
+- Systems covered.
+- Assumptions and TODOs.
+- Example import/use line for the configured engine/language.

--- a/.agents/skills/cgs-test-setup/SKILL.md
+++ b/.agents/skills/cgs-test-setup/SKILL.md
@@ -1,0 +1,61 @@
+---
+name: cgs-test-setup
+description: Use to scaffold Codex Game Studios test infrastructure for the configured engine, including test directories, runner notes, baseline README, and CI workflow guidance. This is the Codex-native replacement for the original Claude Code `/test-setup` workflow.
+metadata:
+  short-description: Scaffold test infrastructure
+---
+
+# Codex Game Studios Test Setup
+
+This skill scaffolds automated and manual testing infrastructure. Run once
+during Technical Setup before the first sprint.
+
+## Inputs To Read
+
+- `.claude/docs/technical-preferences.md` for engine, language, and test
+  framework.
+- Existing `tests/` layout.
+- Existing `.github/workflows/`.
+- Engine reference `VERSION.md`.
+- Original source workflow, only if more detail is needed:
+  `.claude/skills/test-setup/SKILL.md`.
+
+Stop if engine is not configured unless the user asks for engine-agnostic
+placeholders.
+
+## Plan
+
+Propose files before writing:
+
+- `tests/README.md`.
+- `tests/unit/`.
+- `tests/integration/`.
+- `tests/smoke/`.
+- `tests/evidence/`.
+- Engine-specific runner notes or placeholders.
+- `.github/workflows/tests.yml` when the engine/test runner can be specified
+  safely.
+
+Never overwrite existing tests. Use force only if the user explicitly asks and
+understands the replacement.
+
+## Engine Defaults
+
+- Godot: GdUnit4 runner notes and `tests/gdunit4_runner.gd` if appropriate.
+- Unity: EditMode and PlayMode test folders, Unity Test Framework notes.
+- Unreal: Automation Test README and command notes.
+- Unknown: generic structure only.
+
+## Write Output
+
+After approval, create missing directories/files. Prefer placeholders and
+documentation over brittle CI commands when local engine setup is unknown.
+
+## Completion
+
+Finish with:
+
+- Files created.
+- Files skipped because they already existed.
+- Manual setup still required.
+- Test command or "not configured yet" reason.

--- a/.agents/skills/cgs-ux-design/SKILL.md
+++ b/.agents/skills/cgs-ux-design/SKILL.md
@@ -1,0 +1,112 @@
+---
+name: cgs-ux-design
+description: Use to collaboratively author Codex Game Studios UX specs for screens, flows, HUDs, or interaction patterns using game concept, player journey, GDD UI requirements, existing UX docs, art bible, accessibility, and input/platform context. This is the Codex-native replacement for the original Claude Code `/ux-design` workflow.
+metadata:
+  short-description: Author UX specs
+---
+
+# Codex Game Studios UX Design
+
+This skill authors UX documents collaboratively. Do not auto-generate a full
+spec as a fait accompli; UX decisions require user approval.
+
+## Modes
+
+- `hud`: write `design/ux/hud.md`.
+- `patterns`: write `design/ux/interaction-patterns.md`.
+- screen or flow name: write `design/ux/[name].md`.
+
+If no mode is provided, ask what to design.
+
+## Inputs To Read
+
+- `design/gdd/game-concept.md`.
+- `design/player-journey.md`, if present.
+- GDD UI Requirements sections under `design/gdd/`.
+- Existing UX specs under `design/ux/`.
+- `design/ux/interaction-patterns.md`, if present.
+- `design/art/art-bible.md`, if present.
+- `design/accessibility-requirements.md`, if present.
+- Input/platform section from `.claude/docs/technical-preferences.md`.
+- Original source workflow, only if more detail is needed:
+  `.claude/skills/ux-design/SKILL.md`.
+
+## Context Summary
+
+Before authoring, summarize:
+
+- target document and mode.
+- journey phase and player context.
+- GDD requirements found.
+- related UX specs.
+- pattern library status.
+- accessibility tier.
+- input methods and target platforms.
+
+Ask if additional context should be read before starting.
+
+## Retrofit Mode
+
+If the output file already exists:
+
+- read it.
+- classify sections as Complete, Empty, or Placeholder.
+- work only on incomplete sections unless the user requests revisions.
+
+Do not overwrite completed sections silently.
+
+## Authoring Flow
+
+For each section:
+
+1. Explain purpose and relevant constraints.
+2. Ask focused design questions.
+3. Offer options with tradeoffs when choices exist.
+4. Draft the section in conversation.
+5. Ask for approval.
+6. Write only after approval or explicit request.
+
+Create the skeleton first only after approval.
+
+## UX Spec Sections
+
+Use these sections for screen/flow specs:
+
+- Purpose & Player Need.
+- Player Context on Arrival.
+- Navigation Position.
+- Entry & Exit Points.
+- Layout Specification.
+- States & Variants.
+- Interaction Map.
+- Events Fired.
+- Transitions & Animations.
+- Data Requirements.
+- Accessibility.
+- Localization Considerations.
+- Acceptance Criteria.
+- Open Questions.
+
+HUD and pattern-library modes use the matching structures from the original
+workflow, adapted to project needs.
+
+## Cross-Reference Check
+
+Before handoff, check:
+
+- GDD UI requirement coverage.
+- pattern library alignment.
+- navigation consistency.
+- accessibility coverage.
+- empty/error/loading states.
+
+## Completion
+
+Finish with:
+
+- UX file path if written.
+- sections completed.
+- unresolved design questions.
+- cross-reference gaps.
+- next recommended Codex request: UX review, another UX spec, pattern library
+  update, or pre-production gate check.

--- a/.agents/skills/cgs-ux-review/SKILL.md
+++ b/.agents/skills/cgs-ux-review/SKILL.md
@@ -1,0 +1,97 @@
+---
+name: cgs-ux-review
+description: Use to run a read-only Codex Game Studios UX review for one UX spec, all UX specs, HUD design, or interaction patterns, validating completeness, accessibility, input coverage, GDD alignment, pattern consistency, localization, and implementation readiness. This is the Codex-native replacement for the original Claude Code `/ux-review` workflow.
+metadata:
+  short-description: Review UX readiness
+---
+
+# Codex Game Studios UX Review
+
+This skill is read-only. It validates UX design documents before implementation
+handoff and reports risks without editing files.
+
+## Scope
+
+- file path: review one UX document.
+- `all`: review all `design/ux/*.md`.
+- `hud`: review `design/ux/hud.md`.
+- `patterns`: review `design/ux/interaction-patterns.md`.
+
+If missing, ask which spec to validate.
+
+## Inputs To Read
+
+- Target UX document(s).
+- Input/platform section from `.claude/docs/technical-preferences.md`.
+- `design/accessibility-requirements.md`, if present.
+- `design/ux/interaction-patterns.md`, if present.
+- Referenced GDD UI Requirements sections.
+- `design/player-journey.md`, if present.
+- Original source workflow, only if more detail is needed:
+  `.claude/skills/ux-review/SKILL.md`.
+
+## Validate UX Specs
+
+Check:
+
+- required sections present.
+- player need stated from player perspective.
+- arrival context and navigation position.
+- entry and exit points.
+- layout zones and component inventory.
+- loading, empty, error, and progression states.
+- interaction map covers supported input methods.
+- data requirements have source systems and no UI-owned game state.
+- events fired are specified or intentionally absent.
+- transitions and animation behavior.
+- accessibility tier coverage.
+- localization expansion and character limits.
+- acceptance criteria are testable without reading other docs.
+- all GDD UI requirements are covered.
+- pattern library references are consistent.
+
+## Validate HUD
+
+Check:
+
+- HUD philosophy.
+- full information inventory from GDD UI requirements.
+- layout zones and safe margins.
+- element priority, visibility triggers, data source, and update behavior.
+- gameplay context states.
+- visual budget and platform adaptation.
+- colorblind and accessibility support.
+
+## Validate Pattern Library
+
+Check:
+
+- pattern catalog matches document contents.
+- standard control patterns are covered.
+- game-specific patterns from UX specs are included.
+- each pattern defines states, accessibility, when to use, and when not to use.
+- navigation/back behavior is consistent.
+
+## Output
+
+For each reviewed document, generate:
+
+- Completeness score.
+- Quality Issues with `BLOCKING` or `ADVISORY`.
+- GDD Alignment.
+- Accessibility result.
+- Pattern Library result.
+- Verdict: `APPROVED`, `NEEDS REVISION`, or `MAJOR REVISION NEEDED`.
+- Blocking and advisory counts.
+
+For `all`, start with a summary table: file, verdict, primary issue.
+
+## Completion
+
+Finish with:
+
+- verdict.
+- blocking issues.
+- highest-risk implementation gap.
+- next recommended Codex request: fix UX sections, run UX design, team UI, or
+  pre-production gate check.

--- a/.gitignore
+++ b/.gitignore
@@ -14,6 +14,9 @@ Desktop.ini
 CLAUDE.local.md
 production/session-logs/
 
+# === Codex Local ===
+.codex
+
 # === Internal Planning (not for public) ===
 
 expansions/

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,103 @@
+# Codex Game Studios -- Agent Instructions
+
+This repository is an unofficial Codex-oriented fork of Claude Code Game Studios.
+Keep the original MIT license and attribution intact.
+
+## Repository Purpose
+
+This is a game-development workflow template for Codex. It adapts the original
+Claude Code assets into Codex-readable project instructions, skills, reference
+docs, and validation scripts.
+
+The current source-of-truth assets are still under `.claude/` until each area is
+ported:
+
+- `.claude/agents/` contains the original studio role definitions.
+- `.claude/skills/` contains the original slash-command workflows.
+- `.claude/hooks/` contains the original validation and session scripts.
+- `.claude/rules/` contains the original path-scoped standards.
+- `.claude/docs/` contains workflow catalogs, templates, and technical guidance.
+
+When porting, preserve the intent but remove Claude Code-specific assumptions.
+
+## Codex Porting Rules
+
+- Convert Claude slash-command workflows into Codex skills or normal procedural
+  instructions. Do not assume `/command` invocation exists unless a Codex skill
+  explicitly provides it.
+- Convert named Claude subagents into Codex delegation guidance. Codex may use
+  available subagent roles only when the user explicitly asks for delegation or
+  parallel agent work.
+- Convert `AskUserQuestion` steps into concise user questions. In default
+  Codex operation, make reasonable assumptions unless a decision is genuinely
+  blocking or risky.
+- Convert Claude hooks into explicit scripts or checklist-driven validation.
+  Do not assume automatic hook execution unless a Codex plugin implements it.
+- Preserve collaborative control for design work: ask before locking major game
+  direction, architecture decisions, or multi-file workflow rewrites.
+- For implementation work, prefer completing the change end-to-end, including
+  verification, unless the user asks only for planning or analysis.
+
+## Game Project Workflow
+
+Use the original seven-phase pipeline unless the user asks for a lighter flow:
+
+1. Concept
+2. Systems Design
+3. Technical Setup
+4. Pre-Production
+5. Production
+6. Polish
+7. Release
+
+For detailed phase definitions, read `.claude/docs/workflow-catalog.yaml` and
+`docs/WORKFLOW-GUIDE.md`.
+
+## Technology Stack
+
+- **Engine**: [CHOOSE: Godot 4 / Unity / Unreal Engine 5]
+- **Language**: [CHOOSE: GDScript / C# / C++ / Blueprint]
+- **Version Control**: Git with trunk-based development
+- **Build System**: [SPECIFY after choosing engine]
+- **Asset Pipeline**: [SPECIFY after choosing engine]
+
+Use `.claude/docs/technical-preferences.md` until a Codex-native preferences
+file exists.
+
+## Project Structure
+
+- `src/`: game source code
+- `assets/`: art, audio, VFX, shaders, and data files
+- `design/`: GDDs, narrative docs, level designs, balance docs, UX specs
+- `docs/`: technical documentation, ADRs, engine references
+- `tests/`: automated and manual test assets
+- `tools/`: build and pipeline tooling
+- `prototypes/`: isolated throwaway prototypes
+- `production/`: sprints, milestones, releases, session state
+
+## Coding Standards
+
+- Keep gameplay values data-driven; avoid hardcoded balance numbers.
+- Prefer testable system boundaries over hidden singletons.
+- Document public APIs in game code.
+- Add or update ADRs for new architecture decisions.
+- Keep generated or throwaway prototype code under `prototypes/`, not `src/`.
+- Check `docs/engine-reference/` before relying on engine APIs.
+
+## Validation
+
+Run the most relevant checks available for the current engine or workflow. If no
+engine is configured, validate documentation and shell scripts only.
+
+Suggested baseline checks:
+
+```bash
+bash -n .claude/hooks/*.sh
+python3 -m json.tool .claude/settings.json
+```
+
+## Attribution
+
+This fork is based on Claude Code Game Studios by Donchitos. The upstream
+license is MIT; retain `LICENSE` and clearly mark Codex-specific changes as
+unofficial.

--- a/NOTICE.md
+++ b/NOTICE.md
@@ -1,0 +1,11 @@
+# Notice
+
+Codex Game Studios is an unofficial Codex-oriented fork of Claude Code Game
+Studios by Donchitos.
+
+The original project is licensed under the MIT License. The original copyright
+notice and license are retained in `LICENSE`.
+
+This fork adapts the original Claude Code workflows, agents, hooks, and rules
+for Codex-oriented usage. Codex-specific changes are not endorsed by or
+affiliated with the original author unless explicitly stated upstream.

--- a/README.md
+++ b/README.md
@@ -1,9 +1,9 @@
 <p align="center">
-  <h1 align="center">Claude Code Game Studios</h1>
+  <h1 align="center">Codex Game Studios</h1>
   <p align="center">
-    Turn a single Claude Code session into a full game development studio.
+    Unofficial Codex-oriented port of Claude Code Game Studios.
     <br />
-    49 agents. 72 skills. One coordinated AI team.
+    Game development workflows, studio roles, and quality gates for Codex.
   </p>
 </p>
 
@@ -19,6 +19,16 @@
 </p>
 
 ---
+
+> **Fork status:** This repository is an unofficial Codex-oriented fork of
+> [Claude Code Game Studios](https://github.com/Donchitos/Claude-Code-Game-Studios)
+> by Donchitos. The original project is MIT licensed. This fork keeps the
+> upstream `.claude/` assets as source material while adding Codex-readable
+> instructions such as `AGENTS.md`.
+
+> **Porting status:** Early migration. Claude Code workflows are still present.
+> Codex-native instructions have started with `AGENTS.md` and
+> `docs/CODEX-PORTING.md`.
 
 ## Why This Exists
 
@@ -131,6 +141,38 @@ Type `/` in Claude Code to access all 72 skills:
 
 **Team Orchestration** (coordinate multiple agents on a single feature)
 `/team-combat` `/team-narrative` `/team-ui` `/team-release` `/team-polish` `/team-audio` `/team-level` `/team-live-ops` `/team-qa`
+
+## Codex Usage
+
+This fork is being ported to Codex incrementally. The first Codex-native skills
+live in `.agents/skills/`:
+
+- `cgs-start` — first-time onboarding and workflow routing
+- `cgs-help` — read-only "what should I do next?" guidance
+- `cgs-setup-engine` — engine, language, platform, and standards setup
+- `cgs-brainstorm` — concept ideation into `design/gdd/game-concept.md`
+- `cgs-map-systems` — systems decomposition into `design/gdd/systems-index.md`
+- `cgs-design-system` — section-by-section GDD authoring for one system
+- `cgs-design-review` — design/GDD readiness review
+- `cgs-gate-check` — phase transition readiness verdict
+- `cgs-dev-story` — story implementation with tests and acceptance coverage
+
+In Codex, use natural-language requests instead of Claude Code slash commands:
+
+```text
+Start Codex Game Studios onboarding.
+What should I do next in this game project?
+Configure this project for Godot 4.6 with GDScript.
+Brainstorm a game concept from this seed: cozy space salvaging.
+Map the systems for the current game concept.
+Design the next system GDD.
+Review design/gdd/combat-system.md for implementation readiness.
+Run a gate check for the Concept to Systems Design transition.
+Implement production/epics/foundation/STORY-001.md.
+```
+
+The original Claude Code workflows remain available under `.claude/` as source
+material during the migration.
 
 ## Getting Started
 

--- a/README.md
+++ b/README.md
@@ -176,6 +176,11 @@ live in `.agents/skills/`:
 - `cgs-changelog` — internal and player-facing changelog generation
 - `cgs-patch-notes` — public patch notes drafting
 - `cgs-hotfix` — emergency S1/S2 hotfix workflow
+- `cgs-milestone-review` — milestone progress and go/no-go review
+- `cgs-retrospective` — sprint or milestone retrospective
+- `cgs-bug-report` — bug filing, verification, and closure workflow
+- `cgs-bug-triage` — open bug prioritization and trend report
+- `cgs-playtest-report` — playtest template and feedback analysis
 
 In Codex, use natural-language requests instead of Claude Code slash commands:
 
@@ -209,6 +214,11 @@ Run a dry-run launch checklist for July 15.
 Generate the changelog for version 0.3.0.
 Write detailed patch notes for version 0.3.0.
 Start a hotfix workflow for BUG-142.
+Review the current milestone.
+Create a retrospective for sprint 3.
+File a bug report for this crash description.
+Triage open bugs for the current sprint.
+Analyze playtest notes at production/qa/raw-notes/session-04.md.
 ```
 
 The original Claude Code workflows remain available under `.claude/` as source

--- a/README.md
+++ b/README.md
@@ -191,6 +191,11 @@ live in `.agents/skills/`:
 - `cgs-art-bible` — visual identity and asset standards authoring
 - `cgs-asset-spec` — per-asset specs and generation prompts
 - `cgs-asset-audit` — read-only asset compliance audit
+- `cgs-content-audit` — planned-vs-implemented content gap audit
+- `cgs-consistency-check` — cross-GDD registry consistency check
+- `cgs-balance-check` — balance data and formula analysis
+- `cgs-ux-design` — collaborative UX spec authoring
+- `cgs-ux-review` — read-only UX readiness review
 
 In Codex, use natural-language requests instead of Claude Code slash commands:
 
@@ -239,6 +244,11 @@ Prototype this grappling-hook concept.
 Author the art bible from the current game concept.
 Generate asset specs for system:combat.
 Audit all assets for naming and manifest compliance.
+Audit content gaps for all MVP systems.
+Check GDD consistency against the entity registry.
+Run a balance check for the economy.
+Design the inventory UX spec.
+Review all UX specs for implementation readiness.
 ```
 
 The original Claude Code workflows remain available under `.claude/` as source

--- a/README.md
+++ b/README.md
@@ -196,6 +196,11 @@ live in `.agents/skills/`:
 - `cgs-balance-check` — balance data and formula analysis
 - `cgs-ux-design` — collaborative UX spec authoring
 - `cgs-ux-review` — read-only UX readiness review
+- `cgs-review-all-gdds` — holistic cross-GDD review
+- `cgs-propagate-design-change` — ADR impact analysis after GDD changes
+- `cgs-reverse-document` — generate docs from existing implementation
+- `cgs-localize` — localization pipeline workflows
+- `cgs-onboard` — role/area onboarding document generation
 
 In Codex, use natural-language requests instead of Claude Code slash commands:
 
@@ -249,6 +254,11 @@ Check GDD consistency against the entity registry.
 Run a balance check for the economy.
 Design the inventory UX spec.
 Review all UX specs for implementation readiness.
+Review all GDDs before architecture.
+Propagate design changes from design/gdd/combat.md.
+Reverse-document design from src/gameplay/combat.
+Run localization status.
+Create onboarding for a new QA contributor.
 ```
 
 The original Claude Code workflows remain available under `.claude/` as source

--- a/README.md
+++ b/README.md
@@ -186,6 +186,11 @@ live in `.agents/skills/`:
 - `cgs-perf-profile` — performance risk and hotspot analysis
 - `cgs-security-audit` — release security risk audit
 - `cgs-tech-debt` — technical debt scan, register, and report
+- `cgs-quick-design` — lightweight spec for small design changes
+- `cgs-prototype` — isolated throwaway prototype workflow
+- `cgs-art-bible` — visual identity and asset standards authoring
+- `cgs-asset-spec` — per-asset specs and generation prompts
+- `cgs-asset-audit` — read-only asset compliance audit
 
 In Codex, use natural-language requests instead of Claude Code slash commands:
 
@@ -229,6 +234,11 @@ Estimate this inventory refactor.
 Profile performance risk for the combat system.
 Run a quick security audit.
 Scan technical debt and propose register updates.
+Create a quick design spec for a jump-height tuning change.
+Prototype this grappling-hook concept.
+Author the art bible from the current game concept.
+Generate asset specs for system:combat.
+Audit all assets for naming and manifest compliance.
 ```
 
 The original Claude Code workflows remain available under `.claude/` as source

--- a/README.md
+++ b/README.md
@@ -161,6 +161,16 @@ live in `.agents/skills/`:
 - `cgs-create-epics` — convert systems/modules into epics
 - `cgs-create-stories` — break an epic into implementable stories
 - `cgs-story-done` — verify and close implemented stories
+- `cgs-architecture-review` — architecture coverage and engine compatibility review
+- `cgs-create-control-manifest` — generate programmer rules from Accepted ADRs
+- `cgs-story-readiness` — check if stories are implementation-ready
+- `cgs-code-review` — implementation code review
+- `cgs-sprint-plan` — create, update, or summarize sprint plans
+- `cgs-qa-plan` — generate sprint/feature/story QA plans
+- `cgs-smoke-check` — smoke readiness gate before QA handoff
+- `cgs-regression-suite` — audit and maintain regression coverage
+- `cgs-test-setup` — scaffold engine-specific test infrastructure
+- `cgs-test-helpers` — generate test helper utilities
 
 In Codex, use natural-language requests instead of Claude Code slash commands:
 
@@ -179,6 +189,16 @@ Create an ADR for event bus architecture.
 Create Foundation layer epics.
 Break the combat epic into stories.
 Verify story-001 is done.
+Review architecture coverage for the current GDDs.
+Generate the control manifest from accepted ADRs.
+Check readiness for all stories in the current sprint.
+Review the files changed by the current story.
+Create a new sprint plan from ready Foundation stories.
+Generate a QA plan for the current sprint.
+Run a smoke check for the current sprint.
+Audit the regression suite.
+Set up tests for the configured engine.
+Create test helpers for the combat system.
 ```
 
 The original Claude Code workflows remain available under `.claude/` as source

--- a/README.md
+++ b/README.md
@@ -181,6 +181,11 @@ live in `.agents/skills/`:
 - `cgs-bug-report` — bug filing, verification, and closure workflow
 - `cgs-bug-triage` — open bug prioritization and trend report
 - `cgs-playtest-report` — playtest template and feedback analysis
+- `cgs-scope-check` — read-only scope creep review
+- `cgs-estimate` — task effort estimate with confidence
+- `cgs-perf-profile` — performance risk and hotspot analysis
+- `cgs-security-audit` — release security risk audit
+- `cgs-tech-debt` — technical debt scan, register, and report
 
 In Codex, use natural-language requests instead of Claude Code slash commands:
 
@@ -219,6 +224,11 @@ Create a retrospective for sprint 3.
 File a bug report for this crash description.
 Triage open bugs for the current sprint.
 Analyze playtest notes at production/qa/raw-notes/session-04.md.
+Check scope creep for sprint 3.
+Estimate this inventory refactor.
+Profile performance risk for the combat system.
+Run a quick security audit.
+Scan technical debt and propose register updates.
 ```
 
 The original Claude Code workflows remain available under `.claude/` as source

--- a/README.md
+++ b/README.md
@@ -171,6 +171,11 @@ live in `.agents/skills/`:
 - `cgs-regression-suite` — audit and maintain regression coverage
 - `cgs-test-setup` — scaffold engine-specific test infrastructure
 - `cgs-test-helpers` — generate test helper utilities
+- `cgs-release-checklist` — pre-release validation checklist
+- `cgs-launch-checklist` — full launch readiness checklist
+- `cgs-changelog` — internal and player-facing changelog generation
+- `cgs-patch-notes` — public patch notes drafting
+- `cgs-hotfix` — emergency S1/S2 hotfix workflow
 
 In Codex, use natural-language requests instead of Claude Code slash commands:
 
@@ -199,6 +204,11 @@ Run a smoke check for the current sprint.
 Audit the regression suite.
 Set up tests for the configured engine.
 Create test helpers for the combat system.
+Generate a release checklist for PC.
+Run a dry-run launch checklist for July 15.
+Generate the changelog for version 0.3.0.
+Write detailed patch notes for version 0.3.0.
+Start a hotfix workflow for BUG-142.
 ```
 
 The original Claude Code workflows remain available under `.claude/` as source

--- a/README.md
+++ b/README.md
@@ -156,6 +156,11 @@ live in `.agents/skills/`:
 - `cgs-design-review` — design/GDD readiness review
 - `cgs-gate-check` — phase transition readiness verdict
 - `cgs-dev-story` — story implementation with tests and acceptance coverage
+- `cgs-create-architecture` — master architecture blueprint creation
+- `cgs-architecture-decision` — ADR creation and retrofit
+- `cgs-create-epics` — convert systems/modules into epics
+- `cgs-create-stories` — break an epic into implementable stories
+- `cgs-story-done` — verify and close implemented stories
 
 In Codex, use natural-language requests instead of Claude Code slash commands:
 
@@ -169,6 +174,11 @@ Design the next system GDD.
 Review design/gdd/combat-system.md for implementation readiness.
 Run a gate check for the Concept to Systems Design transition.
 Implement production/epics/foundation/STORY-001.md.
+Create the architecture document from the approved GDDs.
+Create an ADR for event bus architecture.
+Create Foundation layer epics.
+Break the combat epic into stories.
+Verify story-001 is done.
 ```
 
 The original Claude Code workflows remain available under `.claude/` as source

--- a/design/AGENTS.md
+++ b/design/AGENTS.md
@@ -1,0 +1,38 @@
+# Design Directory Instructions
+
+Follow these standards when authoring or editing design files.
+
+## GDD Files
+
+Files in `design/gdd/` must include these sections in order:
+
+1. Overview
+2. Player Fantasy
+3. Detailed Rules
+4. Formulas
+5. Edge Cases
+6. Dependencies
+7. Tuning Knobs
+8. Acceptance Criteria
+
+Use `[system-slug].md` filenames such as `movement-system.md` or
+`combat-system.md`.
+
+Update `design/gdd/systems-index.md` when adding a system GDD. Design in this
+order unless the user explicitly chooses otherwise: Foundation, Core, Feature,
+Presentation, Polish.
+
+## Quick Specs
+
+Use `design/quick-specs/` for tuning changes, minor mechanics, and small
+additions that do not need a full GDD.
+
+## UX Specs
+
+- Per-screen specs: `design/ux/[screen-name].md`
+- HUD design: `design/ux/hud.md`
+- Interaction patterns: `design/ux/interaction-patterns.md`
+- Accessibility requirements: `design/ux/accessibility-requirements.md`
+
+Before passing UX work to implementation, check alignment with the relevant GDDs
+and accessibility requirements.

--- a/docs/AGENTS.md
+++ b/docs/AGENTS.md
@@ -1,0 +1,35 @@
+# Docs Directory Instructions
+
+Follow these standards when authoring or editing documentation files.
+
+## Architecture Decisions
+
+Use `.claude/docs/templates/architecture-decision-record.md` as the source
+template until a Codex-native template exists.
+
+ADR files belong in `docs/architecture/` and must include:
+
+- Title
+- Status
+- Context
+- Decision
+- Consequences
+- ADR Dependencies
+- Engine Compatibility
+- GDD Requirements Addressed
+
+Use the lifecycle `Proposed` -> `Accepted` -> `Superseded`. Do not treat a
+`Proposed` ADR as implementation-ready unless the user explicitly accepts the
+risk.
+
+## Traceability
+
+- `docs/architecture/tr-registry.yaml` stores stable requirement IDs.
+- Never renumber existing IDs; append new IDs instead.
+- Stories should reference relevant GDD sections, ADRs, and TR IDs.
+
+## Engine Reference
+
+Engine references in `docs/engine-reference/` are version-pinned snapshots.
+Check them before suggesting engine APIs, especially for Godot, Unity, and
+Unreal versions newer than model training data.

--- a/docs/CODEX-PORTING.md
+++ b/docs/CODEX-PORTING.md
@@ -25,7 +25,8 @@ license and attribution.
   `cgs-scope-check`, `cgs-estimate`, `cgs-perf-profile`,
   `cgs-security-audit`, `cgs-tech-debt`, `cgs-quick-design`,
   `cgs-prototype`, `cgs-art-bible`, `cgs-asset-spec`, and
-  `cgs-asset-audit`.
+  `cgs-asset-audit`, `cgs-content-audit`, `cgs-consistency-check`,
+  `cgs-balance-check`, `cgs-ux-design`, and `cgs-ux-review`.
 - `.codex` is treated as a local Codex runtime file and ignored by Git.
 
 ## Porting Principles
@@ -103,6 +104,7 @@ team orchestration, release, and utility.
 
 ## Next Concrete Step
 
-Port the next content and UX review workflows: `content-audit`,
-`consistency-check`, `balance-check`, `ux-design`, and `ux-review`. Keep each
-skill concise and load original `.claude/` source material only when needed.
+Port the next design-maintenance and documentation workflows:
+`review-all-gdds`, `propagate-design-change`, `reverse-document`, `localize`,
+and `onboard`. Keep each skill concise and load original `.claude/` source
+material only when needed.

--- a/docs/CODEX-PORTING.md
+++ b/docs/CODEX-PORTING.md
@@ -14,7 +14,11 @@ license and attribution.
   `cgs-brainstorm`, `cgs-map-systems`, `cgs-design-system`,
   `cgs-design-review`, `cgs-gate-check`, `cgs-dev-story`,
   `cgs-create-architecture`, `cgs-architecture-decision`,
-  `cgs-create-epics`, `cgs-create-stories`, and `cgs-story-done`.
+  `cgs-create-epics`, `cgs-create-stories`, `cgs-story-done`,
+  `cgs-architecture-review`, `cgs-create-control-manifest`,
+  `cgs-story-readiness`, `cgs-code-review`, `cgs-sprint-plan`,
+  `cgs-qa-plan`, `cgs-smoke-check`, `cgs-regression-suite`,
+  `cgs-test-setup`, and `cgs-test-helpers`.
 - `.codex` is treated as a local Codex runtime file and ignored by Git.
 
 ## Porting Principles
@@ -92,7 +96,6 @@ team orchestration, release, and utility.
 
 ## Next Concrete Step
 
-Port the next review and production-support workflows: `architecture-review`,
-`create-control-manifest`, `story-readiness`, `code-review`, and `sprint-plan`.
-Keep each skill concise and load original `.claude/` source material only when
-needed.
+Port the next release and maintenance workflows: `release-checklist`,
+`launch-checklist`, `changelog`, `patch-notes`, and `hotfix`. Keep each skill
+concise and load original `.claude/` source material only when needed.

--- a/docs/CODEX-PORTING.md
+++ b/docs/CODEX-PORTING.md
@@ -23,7 +23,9 @@ license and attribution.
   `cgs-hotfix`, `cgs-milestone-review`, `cgs-retrospective`,
   `cgs-bug-report`, `cgs-bug-triage`, `cgs-playtest-report`,
   `cgs-scope-check`, `cgs-estimate`, `cgs-perf-profile`,
-  `cgs-security-audit`, and `cgs-tech-debt`.
+  `cgs-security-audit`, `cgs-tech-debt`, `cgs-quick-design`,
+  `cgs-prototype`, `cgs-art-bible`, `cgs-asset-spec`, and
+  `cgs-asset-audit`.
 - `.codex` is treated as a local Codex runtime file and ignored by Git.
 
 ## Porting Principles
@@ -101,6 +103,6 @@ team orchestration, release, and utility.
 
 ## Next Concrete Step
 
-Port the next creative and content workflows: `quick-design`, `prototype`,
-`art-bible`, `asset-spec`, and `asset-audit`. Keep each skill concise and load
-original `.claude/` source material only when needed.
+Port the next content and UX review workflows: `content-audit`,
+`consistency-check`, `balance-check`, `ux-design`, and `ux-review`. Keep each
+skill concise and load original `.claude/` source material only when needed.

--- a/docs/CODEX-PORTING.md
+++ b/docs/CODEX-PORTING.md
@@ -20,7 +20,8 @@ license and attribution.
   `cgs-qa-plan`, `cgs-smoke-check`, `cgs-regression-suite`,
   `cgs-test-setup`, `cgs-test-helpers`, `cgs-release-checklist`,
   `cgs-launch-checklist`, `cgs-changelog`, `cgs-patch-notes`, and
-  `cgs-hotfix`.
+  `cgs-hotfix`, `cgs-milestone-review`, `cgs-retrospective`,
+  `cgs-bug-report`, `cgs-bug-triage`, and `cgs-playtest-report`.
 - `.codex` is treated as a local Codex runtime file and ignored by Git.
 
 ## Porting Principles
@@ -98,6 +99,6 @@ team orchestration, release, and utility.
 
 ## Next Concrete Step
 
-Port the next production and bug-management workflows: `milestone-review`,
-`retrospective`, `bug-report`, `bug-triage`, and `playtest-report`. Keep each
-skill concise and load original `.claude/` source material only when needed.
+Port the next analysis and audit workflows: `scope-check`, `estimate`,
+`perf-profile`, `security-audit`, and `tech-debt`. Keep each skill concise and
+load original `.claude/` source material only when needed.

--- a/docs/CODEX-PORTING.md
+++ b/docs/CODEX-PORTING.md
@@ -12,7 +12,9 @@ license and attribution.
 - Initial repo-local Codex skills exist in `.agents/skills/`.
 - Ported starter workflows: `cgs-start`, `cgs-help`, `cgs-setup-engine`,
   `cgs-brainstorm`, `cgs-map-systems`, `cgs-design-system`,
-  `cgs-design-review`, `cgs-gate-check`, and `cgs-dev-story`.
+  `cgs-design-review`, `cgs-gate-check`, `cgs-dev-story`,
+  `cgs-create-architecture`, `cgs-architecture-decision`,
+  `cgs-create-epics`, `cgs-create-stories`, and `cgs-story-done`.
 - `.codex` is treated as a local Codex runtime file and ignored by Git.
 
 ## Porting Principles
@@ -90,7 +92,7 @@ team orchestration, release, and utility.
 
 ## Next Concrete Step
 
-Port the next planning and closure workflows: `create-architecture`,
-`architecture-decision`, `create-epics`, `create-stories`, and `story-done`.
+Port the next review and production-support workflows: `architecture-review`,
+`create-control-manifest`, `story-readiness`, `code-review`, and `sprint-plan`.
 Keep each skill concise and load original `.claude/` source material only when
 needed.

--- a/docs/CODEX-PORTING.md
+++ b/docs/CODEX-PORTING.md
@@ -18,7 +18,9 @@ license and attribution.
   `cgs-architecture-review`, `cgs-create-control-manifest`,
   `cgs-story-readiness`, `cgs-code-review`, `cgs-sprint-plan`,
   `cgs-qa-plan`, `cgs-smoke-check`, `cgs-regression-suite`,
-  `cgs-test-setup`, and `cgs-test-helpers`.
+  `cgs-test-setup`, `cgs-test-helpers`, `cgs-release-checklist`,
+  `cgs-launch-checklist`, `cgs-changelog`, `cgs-patch-notes`, and
+  `cgs-hotfix`.
 - `.codex` is treated as a local Codex runtime file and ignored by Git.
 
 ## Porting Principles
@@ -96,6 +98,6 @@ team orchestration, release, and utility.
 
 ## Next Concrete Step
 
-Port the next release and maintenance workflows: `release-checklist`,
-`launch-checklist`, `changelog`, `patch-notes`, and `hotfix`. Keep each skill
-concise and load original `.claude/` source material only when needed.
+Port the next production and bug-management workflows: `milestone-review`,
+`retrospective`, `bug-report`, `bug-triage`, and `playtest-report`. Keep each
+skill concise and load original `.claude/` source material only when needed.

--- a/docs/CODEX-PORTING.md
+++ b/docs/CODEX-PORTING.md
@@ -21,7 +21,9 @@ license and attribution.
   `cgs-test-setup`, `cgs-test-helpers`, `cgs-release-checklist`,
   `cgs-launch-checklist`, `cgs-changelog`, `cgs-patch-notes`, and
   `cgs-hotfix`, `cgs-milestone-review`, `cgs-retrospective`,
-  `cgs-bug-report`, `cgs-bug-triage`, and `cgs-playtest-report`.
+  `cgs-bug-report`, `cgs-bug-triage`, `cgs-playtest-report`,
+  `cgs-scope-check`, `cgs-estimate`, `cgs-perf-profile`,
+  `cgs-security-audit`, and `cgs-tech-debt`.
 - `.codex` is treated as a local Codex runtime file and ignored by Git.
 
 ## Porting Principles
@@ -99,6 +101,6 @@ team orchestration, release, and utility.
 
 ## Next Concrete Step
 
-Port the next analysis and audit workflows: `scope-check`, `estimate`,
-`perf-profile`, `security-audit`, and `tech-debt`. Keep each skill concise and
-load original `.claude/` source material only when needed.
+Port the next creative and content workflows: `quick-design`, `prototype`,
+`art-bible`, `asset-spec`, and `asset-audit`. Keep each skill concise and load
+original `.claude/` source material only when needed.

--- a/docs/CODEX-PORTING.md
+++ b/docs/CODEX-PORTING.md
@@ -26,7 +26,9 @@ license and attribution.
   `cgs-security-audit`, `cgs-tech-debt`, `cgs-quick-design`,
   `cgs-prototype`, `cgs-art-bible`, `cgs-asset-spec`, and
   `cgs-asset-audit`, `cgs-content-audit`, `cgs-consistency-check`,
-  `cgs-balance-check`, `cgs-ux-design`, and `cgs-ux-review`.
+  `cgs-balance-check`, `cgs-ux-design`, `cgs-ux-review`,
+  `cgs-review-all-gdds`, `cgs-propagate-design-change`,
+  `cgs-reverse-document`, `cgs-localize`, and `cgs-onboard`.
 - `.codex` is treated as a local Codex runtime file and ignored by Git.
 
 ## Porting Principles
@@ -104,7 +106,6 @@ team orchestration, release, and utility.
 
 ## Next Concrete Step
 
-Port the next design-maintenance and documentation workflows:
-`review-all-gdds`, `propagate-design-change`, `reverse-document`, `localize`,
-and `onboard`. Keep each skill concise and load original `.claude/` source
-material only when needed.
+Port the next QA utility workflows: `soak-test`, `test-evidence-review`,
+`test-flakiness`, `skill-test`, and `skill-improve`. Keep each skill concise and
+load original `.claude/` source material only when needed.

--- a/docs/CODEX-PORTING.md
+++ b/docs/CODEX-PORTING.md
@@ -1,0 +1,96 @@
+# Codex Porting Plan
+
+This fork ports Claude Code Game Studios to Codex while preserving upstream
+license and attribution.
+
+## Current Status
+
+- Fork renamed to `Codex-Game-Studios`.
+- Original Claude Code assets remain under `.claude/`.
+- Codex entry instructions exist in `AGENTS.md`.
+- Directory-scoped Codex instructions exist in `src/`, `design/`, and `docs/`.
+- Initial repo-local Codex skills exist in `.agents/skills/`.
+- Ported starter workflows: `cgs-start`, `cgs-help`, `cgs-setup-engine`,
+  `cgs-brainstorm`, `cgs-map-systems`, `cgs-design-system`,
+  `cgs-design-review`, `cgs-gate-check`, and `cgs-dev-story`.
+- `.codex` is treated as a local Codex runtime file and ignored by Git.
+
+## Porting Principles
+
+- Preserve workflow intent, not tool-specific mechanics.
+- Keep upstream files available until a Codex-native equivalent is tested.
+- Mark Codex-specific behavior as unofficial.
+- Prefer a small set of high-value Codex workflows before converting all 72
+  original skills.
+- Keep validation explicit and runnable from the terminal.
+
+## Mapping
+
+| Claude Code Asset | Codex Equivalent |
+| --- | --- |
+| `CLAUDE.md` | `AGENTS.md` |
+| `directory/CLAUDE.md` | `directory/AGENTS.md` |
+| `.claude/skills/*/SKILL.md` | Codex skills or workflow references |
+| `.claude/agents/*.md` | Role prompt references and delegation guidance |
+| `.claude/hooks/*.sh` | Explicit validation scripts or plugin hooks |
+| `.claude/settings.json` | Instructions, scripts, and optional plugin manifest |
+| `/slash-command` usage | Natural-language requests or Codex skill triggers |
+
+## Recommended Migration Phases
+
+### Phase 1: Foundation
+
+- Add `AGENTS.md` and directory-scoped `AGENTS.md` files.
+- Add this porting plan.
+- Add README attribution and explain the fork status.
+- Decide whether to package the port as a Codex plugin.
+
+### Phase 2: Core Workflows
+
+Port the smallest workflow set needed to use the project end-to-end:
+
+- `start`: orient a new user and detect project state.
+- `help`: identify current phase and next action.
+- `setup-engine`: configure engine, language, platform, and preferences.
+- `brainstorm`: create the game concept.
+- `map-systems`: create the systems index.
+- `design-system`: author one GDD.
+- `gate-check`: validate phase transition readiness.
+- `dev-story`: implement a production story.
+
+### Phase 3: Role Library
+
+Convert the 49 original agent files into compact role references. Codex should
+use them to shape analysis and implementation, not as guaranteed named
+subagents.
+
+### Phase 4: Validation
+
+Convert hooks into explicit checks:
+
+- Session/project state check
+- Commit and push safety checks
+- Asset validation
+- Skill structure validation
+- Gap detection
+
+### Phase 5: Full Catalog
+
+Port the remaining skills by category: authoring, review, analysis, QA, sprint,
+team orchestration, release, and utility.
+
+## Known Differences From Claude Code
+
+- Codex does not automatically expose Claude Code slash commands.
+- Codex does not guarantee the same named subagent roster.
+- Codex does not automatically run `.claude/settings.json` hooks.
+- Interactive `AskUserQuestion` steps should become concise questions or
+  reasonable assumptions, depending on risk.
+- Codex can still use the same documents, templates, and workflow phase model.
+
+## Next Concrete Step
+
+Port the next planning and closure workflows: `create-architecture`,
+`architecture-decision`, `create-epics`, `create-stories`, and `story-done`.
+Keep each skill concise and load original `.claude/` source material only when
+needed.

--- a/src/AGENTS.md
+++ b/src/AGENTS.md
@@ -1,0 +1,28 @@
+# Source Directory Instructions
+
+Follow these standards when writing or editing game code.
+
+## Engine APIs
+
+Check `docs/engine-reference/` before using engine APIs. Do not guess signatures
+for recently changed Godot, Unity, or Unreal APIs.
+
+## Code Quality
+
+- Public APIs require doc comments.
+- Gameplay values must be data-driven and tunable.
+- Prefer dependency injection and explicit ownership over global singletons.
+- Keep UI code from owning core game state.
+- Keep networking server-authoritative when multiplayer is present.
+- Add tests for formulas, edge cases, and gameplay rules.
+
+## Architecture
+
+Every new core system should map back to a GDD and, when it changes technical
+structure, an ADR in `docs/architecture/`.
+
+## Tests
+
+Tests live in `tests/`, not in `src/`. If no test framework exists yet, propose
+or scaffold one based on the selected engine before adding broad production
+code.


### PR DESCRIPTION
Summary: add Codex-native repository instructions and port 54 Claude Code workflows into repo-local Codex skills, updating README and Codex porting documentation. Validation: bash -n .claude/hooks/*.sh; python3 -m json.tool .claude/settings.json; skill frontmatter scan.