### PR TITLE
Complete Codex skill catalog port

### DIFF
--- a/.agents/skills/cgs-adopt/SKILL.md
+++ b/.agents/skills/cgs-adopt/SKILL.md
@@ -1,0 +1,84 @@
+---
+name: cgs-adopt
+description: Use to audit an existing or brownfield Codex Game Studios project for template artifact format compliance and produce a prioritized migration plan. This is the Codex-native replacement for the original Claude Code `/adopt` workflow.
+metadata:
+  short-description: Audit brownfield adoption
+---
+
+# Codex Game Studios Adopt
+
+This skill checks whether existing artifacts will work with the template's
+skills. It is different from stage detection: stage detection asks what exists;
+adoption asks whether the artifacts have the required internal format.
+
+## Modes
+
+- `full`: complete audit. Default.
+- `gdds`: GDD format only.
+- `adrs`: ADR format only.
+- `stories`: story format only.
+- `infra`: registry, manifest, sprint/status, stage, engine reference.
+
+## Inputs To Read
+
+- `production/stage.txt`.
+- `design/gdd/game-concept.md`, `systems-index.md`, and system GDDs.
+- `docs/architecture/adr-*.md`.
+- `production/epics/**/*.md`.
+- `.claude/docs/technical-preferences.md`.
+- `docs/engine-reference/`, `docs/adoption-plan-*.md`.
+- Original source workflow, only if more detail is needed:
+  `.claude/skills/adopt/SKILL.md`.
+
+## Audit Checks
+
+- GDDs: required sections, non-placeholder content, valid status field.
+- ADRs: `Status`, dependencies, engine compatibility, requirements addressed,
+  performance implications.
+- Systems index: valid status values, no parenthetical status text, required
+  columns.
+- Stories: status, acceptance checkboxes, ADR references, TR-ID references,
+  manifest version.
+- Infrastructure: TR registry, control manifest, manifest version,
+  `production/sprint-status.yaml`, `production/stage.txt`, engine reference,
+  architecture traceability.
+- Technical preferences: unconfigured engine/language/rendering/physics and
+  missing budgets or standards.
+
+## Severity
+
+- `BLOCKING`: template skills will likely produce wrong results now.
+- `HIGH`: unsafe or incomplete story/architecture generation.
+- `MEDIUM`: degraded quality or tracking.
+- `LOW`: useful retroactive improvements.
+
+Order migration steps by severity, with infrastructure bootstrapping after
+format blockers.
+
+## Fresh Project Handling
+
+If no meaningful artifacts exist, explain that this is not a brownfield
+adoption case and recommend `cgs-start`. If artifacts may be elsewhere, ask for
+their location.
+
+## Optional Writes
+
+Show the audit summary and gap preview before writing. After approval, create:
+
+```text
+docs/adoption-plan-[date].md
+```
+
+If `production/review-mode.txt` is missing, ask whether to set `full`, `lean`,
+or `solo`; write it only after the user's choice.
+
+## Completion
+
+Finish with:
+
+- Detected phase and engine status.
+- GDD, ADR, story, and infrastructure counts.
+- Gap counts by severity.
+- Highest-priority blocking items.
+- Estimated remediation.
+- One recommended first action.

--- a/.agents/skills/cgs-day-one-patch/SKILL.md
+++ b/.agents/skills/cgs-day-one-patch/SKILL.md
@@ -1,0 +1,94 @@
+---
+name: cgs-day-one-patch
+description: Use to plan and gate a Codex Game Studios day-one patch after gold master or near launch, including scope discipline, rollback planning, focused fixes, targeted QA, patch record, and communication follow-up. This is the Codex-native replacement for the original Claude Code `/day-one-patch` workflow.
+metadata:
+  short-description: Plan a day-one patch
+---
+
+# Codex Game Studios Day-One Patch
+
+This skill treats a day-one patch as a constrained mini-sprint. It is not a
+feature sprint and not a broad refactor pass.
+
+Do not spawn subagents unless the user explicitly asks for delegation or
+parallel agent work. Do not tag, deploy, publish, or merge without explicit
+approval.
+
+## Modes
+
+- `known-bugs`: scope from open bugs.
+- `cert-feedback`: scope from platform/cert feedback.
+- `all`: inspect all available launch patch inputs.
+
+If omitted, use `all`.
+
+## Inputs To Read
+
+- `production/stage.txt`.
+- Latest release gate report in `production/gate-checks/`.
+- `production/qa/bugs/*.md` with open or pending verification status.
+- Latest sprint/milestone/release docs.
+- Latest security audit under `production/security/`, if present.
+- Build/release tags or release candidate notes.
+- Original source workflow, only if more detail is needed:
+  `.claude/skills/day-one-patch/SKILL.md`.
+
+## Scope Rules
+
+Include only fixes that are safe and necessary:
+
+- S1/S2 or P1/P2 bugs if the fix is low risk.
+- Cert-required fixes.
+- Data/config-only fixes.
+- Fixes estimated under 4 hours.
+
+Defer:
+
+- New features.
+- Refactors.
+- Architecture changes.
+- Risky new code paths.
+- Fixes better suited for patch 1.1.
+
+If total effort exceeds one day, recommend reducing scope.
+
+## Pipeline
+
+1. Load release context and confirm the project is in Polish or Release.
+2. Classify open bugs and cert feedback into included and deferred items.
+3. Present scope for approval. If no patch is needed, recommend launch checklist.
+4. Define rollback plan before implementation work.
+5. For approved fixes, keep implementation minimal and targeted.
+6. Run targeted smoke or broader regression based on touched systems.
+7. Generate a patch record after approval:
+   `production/releases/day-one-patch-[version].md`.
+8. Recommend player-facing patch notes and post-launch verification.
+
+## Rollback Plan
+
+Before fixes ship, document:
+
+- Base/gold master build.
+- Platform rollback constraints.
+- Rollback owner.
+- Trigger conditions.
+- Player communication if rollback occurs.
+
+Suggested path:
+
+```text
+production/releases/rollback-plan-[version].md
+```
+
+## Completion
+
+Finish with:
+
+- Included and deferred bugs.
+- Scope risk and estimated effort.
+- Rollback plan status.
+- QA gate verdict.
+- Patch record path, if written.
+- Remaining launch risks.
+- Recommended next request: patch notes, bug verification, launch checklist, or
+  retrospective.

--- a/.agents/skills/cgs-project-stage-detect/SKILL.md
+++ b/.agents/skills/cgs-project-stage-detect/SKILL.md
@@ -1,0 +1,76 @@
+---
+name: cgs-project-stage-detect
+description: Use to analyze a Codex Game Studios project state, detect its current development phase, identify artifact gaps, and recommend next steps from existing files. This is the Codex-native replacement for the original Claude Code `/project-stage-detect` workflow.
+metadata:
+  short-description: Detect project stage
+---
+
+# Codex Game Studios Project Stage Detect
+
+This skill scans existing artifacts to answer "where are we?" It is diagnostic
+and read-only unless the user approves writing a report.
+
+## Modes
+
+- `general`: holistic scan. Default.
+- `programmer`: focus on architecture, code, tests, ADRs.
+- `designer`: focus on GDDs, prototypes, systems, levels, narrative.
+- `producer`: focus on sprint plans, milestones, roadmap, stage gates.
+
+## Inputs To Read
+
+- `production/stage.txt`, if present. Treat as authoritative.
+- `design/gdd/`, `design/narrative/`, `design/levels/`.
+- `src/`, `prototypes/`, `tests/`.
+- `docs/architecture/`, ADRs, and `docs/engine-reference/`.
+- `production/sprints/`, milestones, roadmap, and session state.
+- Original source workflow, only if more detail is needed:
+  `.claude/skills/project-stage-detect/SKILL.md`.
+
+## Stage Heuristics
+
+If `production/stage.txt` is absent, infer from most advanced reliable signal:
+
+- Concept: no concept doc or only brainstorming artifacts.
+- Systems Design: concept exists, systems index missing or incomplete.
+- Technical Setup: systems index exists, engine not configured.
+- Pre-Production: engine configured, source code is minimal.
+- Production: active source/story/sprint development exists.
+- Polish: explicit stage gate only.
+- Release: explicit stage gate only.
+
+Report confidence as `PASS`, `CONCERNS`, or `FAIL`.
+
+## Gap Analysis
+
+Do not just list missing files. For each important gap, explain the implication
+and ask or recommend the next safe workflow:
+
+- Code exists without GDD: suggest reverse-documenting or confirming prototype
+  status.
+- ADRs exist without architecture overview: suggest architecture review or
+  reverse-documenting.
+- Concept exists without systems index: suggest `cgs-map-systems`.
+- Prototypes lack READMEs: suggest reverse-documenting or archiving.
+- No sprint plan: ask whether work is tracked elsewhere.
+
+## Optional Report
+
+Default output is a concise stage report in the response. After approval, write:
+
+```text
+production/project-stage-report.md
+```
+
+Use the template intent from `.claude/docs/templates/project-stage-report.md` if
+available.
+
+## Completion
+
+Finish with:
+
+- Detected stage and confidence.
+- Completeness overview for design, code, architecture, production, tests.
+- Highest-impact gaps.
+- Role-filtered recommendations, if requested.
+- One concrete next Codex request.

--- a/.agents/skills/cgs-skill-improve/SKILL.md
+++ b/.agents/skills/cgs-skill-improve/SKILL.md
@@ -1,0 +1,66 @@
+---
+name: cgs-skill-improve
+description: Use to improve an existing Codex Game Studios skill with a baseline validation, focused patch, retest, and non-destructive rollback guidance if the patch does not improve quality. This is the Codex-native replacement for the original Claude Code `/skill-improve` workflow.
+metadata:
+  short-description: Improve a Codex skill
+---
+
+# Codex Game Studios Skill Improve
+
+This skill improves one existing `.agents/skills/[name]/SKILL.md` file through a
+test-fix-retest loop.
+
+## Required Target
+
+The user must name one skill or provide one skill path. If missing, ask for it.
+Do not improve the whole catalog in this workflow; use `cgs-skill-test` first.
+
+## Inputs To Read
+
+- Target `.agents/skills/[name]/SKILL.md`.
+- `cgs-skill-test` findings for the target, if available.
+- Matching `.claude/skills/[source]/SKILL.md`, only when checking port fidelity.
+- `README.md` and `docs/CODEX-PORTING.md` if the skill list or status may need
+  updates.
+- Original source workflow, only if more detail is needed:
+  `.claude/skills/skill-improve/SKILL.md`.
+
+## Workflow
+
+1. Run or simulate `cgs-skill-test spec [name]` as the baseline.
+2. Identify the smallest set of changes that improves correctness, safety, or
+   Codex compatibility.
+3. Explain the proposed patch before writing.
+4. After approval, edit only the target skill and directly related indexes.
+5. Retest the target with the same checks.
+6. Keep the patch only if quality improves or the user explicitly accepts the
+   tradeoff.
+
+## Improvement Targets
+
+Prioritize:
+
+- Clearer trigger description.
+- Missing inputs, outputs, or completion criteria.
+- Unsafe write behavior or missing approval point.
+- Claude-only assumptions not valid in Codex.
+- Overly verbose instructions that can be shortened without losing behavior.
+- Missing source mapping to the original `.claude/skills/` workflow.
+
+Avoid stylistic rewrites with no behavioral benefit.
+
+## Rollback Safety
+
+Do not use destructive commands such as `git reset --hard` or `git checkout --`.
+If a patch should be reverted, ask first and revert with a safe explicit patch
+or a new corrective edit.
+
+## Completion
+
+Finish with:
+
+- Baseline verdict.
+- Changes made.
+- Retest verdict.
+- Residual warnings.
+- Whether README or porting docs were updated.

--- a/.agents/skills/cgs-skill-test/SKILL.md
+++ b/.agents/skills/cgs-skill-test/SKILL.md
@@ -1,0 +1,81 @@
+---
+name: cgs-skill-test
+description: Use to validate repo-local Codex Game Studios skills under `.agents/skills/` for frontmatter, Codex compatibility, workflow quality, safety, and source mapping. This is the Codex-native replacement for the original Claude Code `/skill-test` workflow.
+metadata:
+  short-description: Validate Codex skills
+---
+
+# Codex Game Studios Skill Test
+
+This skill validates Codex skills in `.agents/skills/`. It may also compare
+against original `.claude/skills/` source material when that helps assess a
+port, but `.agents/skills/` is the Codex source of truth.
+
+## Modes
+
+- `static`: validate all Codex skills. Default mode.
+- `spec [skill-name]`: validate one skill in detail.
+- `category [name]`: validate a category such as QA, release, or design.
+- `audit`: check naming, source mapping, and migration consistency.
+
+## Inputs To Read
+
+- `.agents/skills/*/SKILL.md`.
+- Matching `.claude/skills/*/SKILL.md`, only when source comparison is needed.
+- `README.md` Codex Usage list.
+- `docs/CODEX-PORTING.md`.
+- Original source workflow, only if more detail is needed:
+  `.claude/skills/skill-test/SKILL.md`.
+
+## Required Checks
+
+Check each skill for:
+
+- YAML frontmatter with `name`, `description`, and `metadata.short-description`.
+- Folder name matches `name`.
+- Description states when to use the skill, not only what it is.
+- Body has a clear purpose, inputs, workflow, outputs, and completion criteria.
+- Output paths are explicit when the skill writes files.
+- Validation or evidence expectations are stated when relevant.
+- Content is concise enough for Codex progressive disclosure.
+
+## Codex Compatibility Checks
+
+Flag:
+
+- Claude slash-command assumptions as required invocation behavior.
+- Guaranteed named Claude subagent routing.
+- Automatic Claude hook execution assumptions.
+- `AskUserQuestion` or Claude-only tool references.
+- Broad rewrites or major direction changes without user approval.
+- Missing note that Codex should use reasonable assumptions unless a decision is
+  genuinely blocking or risky.
+
+Use original workflow intent as context, but do not require Claude-specific
+implementation details.
+
+## Output Format
+
+Report:
+
+- Summary counts: pass, warning, fail.
+- Findings table with severity, skill, location, issue, recommendation.
+- Source mapping gaps, if any.
+- Highest-value fixes.
+
+By default, do not edit files. If the user asks for a persisted report, or after
+approval, create:
+
+```text
+production/qa/skill-test-[date].md
+```
+
+## Completion
+
+Finish with:
+
+- Overall skill catalog verdict.
+- Blocking issues.
+- Warnings worth fixing later.
+- Suggested next Codex request: improve the highest-risk skill or continue
+  porting the next category.

--- a/.agents/skills/cgs-soak-test/SKILL.md
+++ b/.agents/skills/cgs-soak-test/SKILL.md
@@ -1,0 +1,77 @@
+---
+name: cgs-soak-test
+description: Use to create a Codex Game Studios extended play soak test protocol for memory, stability, balance, or all-up validation. This is the Codex-native replacement for the original Claude Code `/soak-test` workflow.
+metadata:
+  short-description: Create a soak test protocol
+---
+
+# Codex Game Studios Soak Test
+
+This skill creates a protocol for a human-run extended play session. Codex
+prepares the test; it does not claim the soak test was executed unless evidence
+is provided.
+
+## Modes
+
+- `30m`, `1h`, `2h`, `4h`: requested duration.
+- `memory`: memory growth, leaks, allocation spikes.
+- `stability`: crashes, freezes, error logs, recovery.
+- `balance`: economy, progression, combat/resource drift over time.
+- `all`: default when no focus is specified.
+
+If duration or focus is missing, infer only when the request is clear; otherwise
+ask one concise question.
+
+## Inputs To Read
+
+- `.claude/docs/technical-preferences.md`.
+- `design/gdd/game-concept.md` and relevant system GDDs.
+- Latest `production/qa/qa-plan-*.md`, smoke report, or playtest report.
+- `docs/engine-reference/`, if present.
+- Original source workflow, only if more detail is needed:
+  `.claude/skills/soak-test/SKILL.md`.
+
+## Protocol Contents
+
+Generate:
+
+- Scope: build, platform, duration, focus, feature area, exclusions.
+- Preconditions: build source, save state, settings, hardware, tools open.
+- Script: startup steps, repeated actions, scenario rotation, recovery checks.
+- Checkpoint schedule: timed checkpoints with metrics and questions.
+- Evidence requirements: screenshots, logs, profiler captures, save files, notes.
+- Pass criteria: `PASS`, `PASS WITH CONCERNS`, or `FAIL`.
+- Escalation rules for crashes, data loss, severe performance drops, or blocked
+  progression.
+
+## Monitoring Guidance
+
+Use configured engine guidance when available:
+
+- Godot: debugger monitors, output log, scene tree state, resource/memory view.
+- Unity: Profiler, Memory Profiler, console log, Player.log.
+- Unreal: Unreal Insights, `stat unit`, `stat fps`, `stat memory`, crash logs.
+- Unknown engine: frame rate, memory, CPU/GPU load, save/load behavior, logs.
+
+Do not invent exact profiler commands if the engine version is unknown. Mark
+unknowns as assumptions.
+
+## Write Output
+
+Show a short summary first. After approval, create `production/qa/` and write:
+
+```text
+production/qa/soak-test-[date]-[duration].md
+```
+
+Use the local date. Do not overwrite an existing protocol without approval.
+
+## Completion
+
+Finish with:
+
+- Protocol path.
+- Duration and focus.
+- Required evidence.
+- Human execution reminder.
+- Recommended follow-up: evidence review or bug triage after the soak test.

--- a/.agents/skills/cgs-sprint-status/SKILL.md
+++ b/.agents/skills/cgs-sprint-status/SKILL.md
@@ -1,0 +1,64 @@
+---
+name: cgs-sprint-status
+description: Use to produce a fast read-only Codex Game Studios sprint progress snapshot from sprint plans, sprint-status.yaml, story files, dates, blockers, stale work, and burndown risk. This is the Codex-native replacement for the original Claude Code `/sprint-status` workflow.
+metadata:
+  short-description: Check sprint status
+---
+
+# Codex Game Studios Sprint Status
+
+This skill is read-only. It provides situational awareness, not sprint
+replanning. It should stay concise and make at most one concrete recommendation.
+
+## Scope
+
+- Blank: use `production/sprint-status.yaml` if present, otherwise the latest
+  `production/sprints/*.md`.
+- Sprint number/name: find matching sprint markdown or status record.
+
+If no sprint files exist, report that no sprint is active and recommend
+`cgs-sprint-plan`.
+
+## Inputs To Read
+
+- `production/sprint-status.yaml`, if present. Treat as authoritative.
+- Matching or latest `production/sprints/*.md`.
+- Referenced story files under `production/epics/`.
+- Source paths only as lightweight implementation-evidence hints.
+- Original source workflow, only if more detail is needed:
+  `.claude/skills/sprint-status/SKILL.md`.
+
+## Checks
+
+- Sprint goal, start date, end date, owners, priorities, estimates.
+- Story/task status: DONE, COMPLETE, IN PROGRESS, BLOCKED, NOT STARTED, MISSING.
+- Days elapsed, days remaining, and percent time consumed when dates exist.
+- Completion percent.
+- Must-have stories at risk.
+- Missing story files.
+- IN PROGRESS staleness from `Last Updated`, `Updated`, `updated`, or similar
+  fields. More than 2 days stale upgrades burndown risk to at least `At Risk`.
+
+## Burndown Verdict
+
+- `On Track`: completion is within 10 points of time consumed, or ahead.
+- `At Risk`: completion is 10-25 points behind, or stale in-progress work exists.
+- `Behind`: completion is more than 25 points behind.
+- `Unknown`: dates are unavailable.
+
+## Output
+
+Keep the response short:
+
+- Sprint header and goal.
+- Days remaining.
+- Progress count and percentage.
+- Compact story/status table.
+- Attention needed section only if relevant.
+- Burndown verdict.
+- Must-haves at risk.
+- Emerging risks.
+- One recommendation.
+
+Do not write files, update story status, or propose scope cuts. Use
+`cgs-sprint-plan` for replanning.

--- a/.agents/skills/cgs-team-audio/SKILL.md
+++ b/.agents/skills/cgs-team-audio/SKILL.md
@@ -1,0 +1,70 @@
+---
+name: cgs-team-audio
+description: Use to coordinate a Codex Game Studios audio feature or area through direction, sound design, accessibility, technical integration, gameplay triggers, and asset planning. This is the Codex-native replacement for the original Claude Code `/team-audio` workflow.
+metadata:
+  short-description: Coordinate audio feature work
+---
+
+# Codex Game Studios Team Audio
+
+This skill coordinates the audio pipeline for a feature or area. Do not spawn
+subagents unless the user explicitly asks for delegation or parallel agent work;
+otherwise synthesize the role perspectives locally.
+
+## Required Input
+
+Require a feature or area, such as `combat`, `main menu`, `forest biome`, or
+`boss encounter`. If missing, ask for the target.
+
+## Roles To Simulate Or Delegate
+
+- Audio director: sonic identity, emotion, palette, music direction.
+- Sound designer: SFX specs, audio events, mix groups, ducking.
+- Accessibility specialist: captions, visual alternatives, sensitivity risks.
+- Technical artist: middleware/native setup, buses, memory, audio-reactive VFX.
+- Engine specialist: idiomatic engine audio implementation.
+- Gameplay programmer: audio manager, triggers, adaptive music, tests.
+
+## Inputs To Read
+
+- Relevant GDDs under `design/gdd/`.
+- `design/gdd/sound-bible.md`, if present.
+- Existing audio docs and `assets/audio/`.
+- `.claude/docs/technical-preferences.md`.
+- Existing audio code, middleware config, and tests.
+- Original source workflow, only if more detail is needed:
+  `.claude/skills/team-audio/SKILL.md`.
+
+## Pipeline
+
+1. Context: summarize target, existing audio assets, design constraints, engine,
+   and accessibility requirements.
+2. Audio direction: define sonic identity, emotional tone, music/adaptive layer
+   needs, mix priorities, and audio palette.
+3. Sound design: list audio events, trigger conditions, categories, parameters,
+   attenuation, variation, bus/mix group, and asset estimates.
+4. Accessibility: identify critical audio cues, visual fallbacks, caption text,
+   subtitle timing, and sensitivity risks.
+5. Technical integration: choose middleware/native path, bus routing, memory
+   budget, streaming/preload strategy, and engine-specific patterns.
+6. Gameplay integration: define trigger ownership, audio manager/API needs,
+   adaptive music rules, occlusion/reverb zones, and tests.
+7. Documentation: ask before writing `design/gdd/audio-[feature].md`.
+
+## Safety
+
+- Do not communicate critical gameplay state by audio alone.
+- Keep player-facing audio text localization-ready.
+- Do not introduce middleware or architecture changes without explicit approval.
+- Flag missing GDD or sound bible context instead of inventing canon.
+
+## Completion
+
+Finish with:
+
+- Audio event count and key categories.
+- Estimated asset count.
+- Accessibility requirements.
+- Technical integration tasks.
+- Open questions and blockers.
+- Recommended next request: asset spec, dev story, asset audit, or team polish.

--- a/.agents/skills/cgs-team-combat/SKILL.md
+++ b/.agents/skills/cgs-team-combat/SKILL.md
@@ -1,0 +1,79 @@
+---
+name: cgs-team-combat
+description: Use to coordinate a Codex Game Studios combat feature from mechanic design through architecture, implementation, feedback, QA, and sign-off. This is the Codex-native replacement for the original Claude Code `/team-combat` workflow.
+metadata:
+  short-description: Coordinate combat feature work
+---
+
+# Codex Game Studios Team Combat
+
+This skill coordinates combat feature delivery. In Codex, do not spawn
+subagents unless the user explicitly asks for delegation or parallel agent work.
+Without that request, perform the orchestration locally and present role-based
+analysis, plans, and checkpoints.
+
+## Required Input
+
+Require a combat feature description. If missing, ask for the feature or area,
+for example `melee parry system` or `ranged weapon spread`.
+
+## Roles To Simulate Or Delegate
+
+- Game design: mechanic rules, formulas, player fantasy, edge cases.
+- Gameplay programming: core implementation, data flow, tuning knobs.
+- AI programming: NPC reactions and behavior changes, if relevant.
+- Technical art: VFX, shaders, camera feedback, visual readability.
+- Sound design: audio events, impact feedback, mix notes.
+- Engine specialist: idiomatic engine architecture and version constraints.
+- QA: acceptance tests, edge cases, performance checks.
+
+If subagents are explicitly requested, delegate only bounded, independent
+subtasks and keep file ownership disjoint.
+
+## Inputs To Read
+
+- `design/gdd/game-concept.md`.
+- Relevant combat/system GDDs under `design/gdd/`.
+- `docs/architecture/`, ADRs, and `docs/architecture/control-manifest.md`.
+- `.claude/docs/technical-preferences.md`.
+- Existing combat source, assets, audio, and tests.
+- Original source workflow, only if more detail is needed:
+  `.claude/skills/team-combat/SKILL.md`.
+
+## Pipeline
+
+1. Design: create or update the mechanic spec with rules, formulas, edge cases,
+   dependencies, tuning knobs, and acceptance criteria. Ask before locking major
+   design direction or writing GDD files.
+2. Architecture: propose class/node/component structure, data files, events, and
+   integration points. Validate against ADRs and engine preferences.
+3. Implementation: implement core gameplay first, then AI, VFX, and audio
+   integration. Keep tuning data-driven.
+4. Integration: wire systems together and verify events, data ownership, and
+   player feedback.
+5. Validation: add or identify tests, manual QA steps, performance checks, and
+   balance follow-up.
+6. Sign-off: report `COMPLETE`, `NEEDS WORK`, or `BLOCKED`.
+
+## Blocking Rules
+
+Stop and ask before proceeding when:
+
+- Required GDD or story context is missing.
+- An ADR needed for implementation is only Proposed.
+- The feature is too large for one pass and should be split into stories.
+- Design, ADR, and story requirements conflict.
+- A phase depends on unfinished output from a prior phase.
+
+Always produce a partial report if blocked.
+
+## Completion
+
+Finish with:
+
+- Design status.
+- Architecture status.
+- Implementation and asset/audio status.
+- Test and QA evidence status.
+- Open issues with owners or suggested follow-up.
+- Recommended next request: code review, balance check, or team polish.

--- a/.agents/skills/cgs-team-level/SKILL.md
+++ b/.agents/skills/cgs-team-level/SKILL.md
@@ -1,0 +1,69 @@
+---
+name: cgs-team-level
+description: Use to coordinate a Codex Game Studios level or area design through narrative purpose, world context, layout, encounters, art direction, accessibility, QA, and design document output. This is the Codex-native replacement for the original Claude Code `/team-level` workflow.
+metadata:
+  short-description: Coordinate level design
+---
+
+# Codex Game Studios Team Level
+
+This skill coordinates complete level or area design. Do not spawn subagents
+unless the user explicitly asks for delegation or parallel agent work; otherwise
+combine the role perspectives locally.
+
+## Required Input
+
+Require a level name or area, such as `tutorial`, `forest dungeon`, `hub town`,
+or `final boss arena`. If missing, ask for the target.
+
+## Roles To Simulate Or Delegate
+
+- Narrative director: story purpose, emotional arc, characters, beats.
+- World builder: lore, region/faction context, environmental storytelling.
+- Art director: visual landmarks, lighting, color, shape language, assets.
+- Level designer: layout, critical path, pacing, encounters, navigation.
+- Systems designer: enemy composition, rewards, hazards, resource placement.
+- Accessibility specialist: wayfinding, contrast, cognitive load, signposting.
+- QA tester: softlock, boundary, sequence break, playtest checklist.
+
+## Inputs To Read
+
+- `design/gdd/game-concept.md` and `design/gdd/game-pillars.md`, if present.
+- Existing `design/levels/`.
+- Relevant `design/narrative/`, world, art bible, and GDD docs.
+- Acceptance criteria and system constraints for the area.
+- Original source workflow, only if more detail is needed:
+  `.claude/skills/team-level/SKILL.md`.
+
+## Pipeline
+
+1. Direction: define narrative purpose, lore context, emotional arc, visual
+   targets, and landmarks before layout.
+2. Layout: design critical path, optional paths, secrets, entry/exit points,
+   adjacent-area references, pacing, and navigation.
+3. Adjacent dependency check: if referenced adjacent areas have no
+   `design/levels/[area].md`, mark them `UNRESOLVED` or ask whether to design
+   them first. Do not invent adjacent area content.
+4. Systems: specify encounters, difficulty, loot, hazards, resource placement,
+   save/shop/checkpoint needs, and area-specific mechanics.
+5. Production concepts: define key-space art specs, shared vs unique assets,
+   lighting/sight lines, VFX needs, and visual risks.
+6. Accessibility: review signposting, colorblind safety, cognitive load, and
+   contrast. Stop before sign-off on blocking concerns unless the user accepts
+   the documented risk.
+7. QA: define critical-path tests, boundary/softlock cases, playtest checklist,
+   and completion acceptance criteria.
+8. Documentation: ask before writing `design/levels/[level-name].md`.
+
+## Completion
+
+Finish with:
+
+- Area overview.
+- Encounter and asset estimates.
+- Narrative beats.
+- Adjacent-area dependencies.
+- Accessibility concerns and resolution status.
+- QA checklist status.
+- Verdict: `COMPLETE` or `BLOCKED`.
+- Recommended next request: design review, QA plan, or dev story.

--- a/.agents/skills/cgs-team-live-ops/SKILL.md
+++ b/.agents/skills/cgs-team-live-ops/SKILL.md
@@ -1,0 +1,74 @@
+---
+name: cgs-team-live-ops
+description: Use to coordinate a Codex Game Studios live-ops season, event, or post-launch content update through scope, narrative, economy, analytics, content writing, communication, ethics review, and production handoff. This is the Codex-native replacement for the original Claude Code `/team-live-ops` workflow.
+metadata:
+  short-description: Coordinate live-ops planning
+---
+
+# Codex Game Studios Team Live Ops
+
+This skill plans seasons, events, and live content updates. Do not spawn
+subagents unless the user explicitly asks for delegation or parallel agent work.
+
+## Required Input
+
+Require a season name or event description. If missing, ask for the target.
+
+## Roles To Simulate Or Delegate
+
+- Live-ops designer: season structure, cadence, retention hooks.
+- Economy designer: reward track, currencies, pricing, pity/bad-luck protection.
+- Analytics engineer: success metrics, A/B tests, telemetry, dashboards.
+- Community manager: player-facing messaging and communication cadence.
+- Narrative director: seasonal theme, world framing, story hook.
+- Writer: event text, item names, challenge text, flavor copy.
+
+## Inputs To Read
+
+- `design/gdd/game-concept.md`.
+- Existing `design/live-ops/`, seasons, economy rules, and ethics policy.
+- Current economy/balance docs.
+- Narrative/lore docs relevant to the event.
+- Telemetry/analytics docs and community notes.
+- Original source workflow, only if more detail is needed:
+  `.claude/skills/team-live-ops/SKILL.md`.
+
+## Pipeline
+
+1. Scope: define event type, duration, theme direction, content list, reuse vs
+   new content, and retention loop.
+2. Narrative: connect the event to the world, story hook, lore threads, and
+   player-facing premise.
+3. Economy: design reward tracks, free/premium value, seasonal currency, store
+   rotation, pricing, random elements, and bad-luck protection.
+4. Analytics: define participation, retention, completion, conversion, and
+   satisfaction metrics; specify telemetry events and dashboard needs.
+5. Content writing: draft event names, reward descriptions, challenge text,
+   flavor text, and any in-game narrative copy.
+6. Communication: plan teaser, launch, mid-season, final-week, known-issues,
+   and platform-specific copy.
+7. Ethics review: check `design/live-ops/ethics-policy.md`. If missing, flag
+   `ETHICS REVIEW SKIPPED`. If violated, block `COMPLETE` until revised or
+   explicitly overridden with rationale.
+8. Documentation: ask before writing season, analytics, and comms docs under
+   `design/live-ops/`.
+
+## Output Paths
+
+Suggested outputs:
+
+- `design/live-ops/seasons/S[N]_[name].md`.
+- `design/live-ops/seasons/S[N]_[name]_analytics.md`.
+- `design/live-ops/seasons/S[N]_[name]_comms.md`.
+
+## Completion
+
+Finish with:
+
+- Season/event theme and scope.
+- Economy health and ethics status.
+- Success metrics and instrumentation gaps.
+- Content inventory.
+- Communication plan.
+- Open decisions and blockers.
+- Recommended next request: design review, sprint plan, or team release.

--- a/.agents/skills/cgs-team-narrative/SKILL.md
+++ b/.agents/skills/cgs-team-narrative/SKILL.md
@@ -1,0 +1,78 @@
+---
+name: cgs-team-narrative
+description: Use to coordinate Codex Game Studios narrative content through story direction, lore, dialogue, visual storytelling, level integration, localization readiness, and consistency review. This is the Codex-native replacement for the original Claude Code `/team-narrative` workflow.
+metadata:
+  short-description: Coordinate narrative content
+---
+
+# Codex Game Studios Team Narrative
+
+This skill coordinates narrative content. Do not spawn subagents unless the user
+explicitly asks for delegation or parallel agent work; otherwise synthesize the
+role perspectives locally.
+
+## Required Input
+
+Require a narrative content description, such as `boss encounter cutscene`,
+`faction intro dialogue`, or `tutorial narrative`. If missing, ask for the
+target.
+
+## Roles To Simulate Or Delegate
+
+- Narrative director: story beat, character motivation, arc, tone, pacing.
+- Writer: dialogue, lore entries, item text, in-game copy.
+- World builder: canon, factions, history, geography, world rules.
+- Art director: character visual profiles and environmental storytelling.
+- Level designer: narrative triggers, discovery points, pacing in space.
+- Localization lead: string keys, expansion headroom, cultural review.
+
+## Inputs To Read
+
+- `design/gdd/game-concept.md`.
+- Existing `design/narrative/`, character, lore, and world docs.
+- Relevant level docs and GDDs.
+- Localization standards or `design/localization/`, if present.
+- Art bible or visual direction docs.
+- Original source workflow, only if more detail is needed:
+  `.claude/skills/team-narrative/SKILL.md`.
+
+## Pipeline
+
+1. Narrative direction: define purpose, story beat, characters, motivations,
+   emotional tone, pacing, dependencies, and new lore introduced.
+2. World foundation: check lore consistency, define factions/locations/history,
+   and set canon level for new entries.
+3. Writing: draft dialogue and text with string keys, named placeholders,
+   dialogue-box limits, and localization headroom.
+4. Visual storytelling: define character silhouettes, environment props,
+   lighting/cinematic tone, and spatial story clues.
+5. Level integration: place triggers, dialogue zones, discovery points, and
+   environmental storytelling beats without breaking gameplay pacing.
+6. Consistency review: verify voice profiles, lore contradictions, unresolved
+   mysteries, and documented true answers.
+7. Localization readiness: check string keys, formatting, expansion budget,
+   cultural assumptions, and translation-risk notes.
+8. Documentation: ask before writing narrative, dialogue, or lore files.
+
+## Blocking Rules
+
+Stop and ask when:
+
+- Existing canon contradicts the new content.
+- Character voice or lore source is missing.
+- New player-facing text lacks localization path.
+- The narrative change alters major game direction or level structure.
+
+Always produce a partial report if blocked.
+
+## Completion
+
+Finish with:
+
+- Narrative brief status.
+- Lore entries created or needed.
+- Dialogue/text status.
+- Level integration points.
+- Localization readiness.
+- Unresolved contradictions or canon decisions.
+- Recommended next request: design review, localize extract, or dev story.

--- a/.agents/skills/cgs-team-polish/SKILL.md
+++ b/.agents/skills/cgs-team-polish/SKILL.md
@@ -1,0 +1,71 @@
+---
+name: cgs-team-polish
+description: Use to coordinate a Codex Game Studios polish pass for a feature or area across performance, visuals, audio, tools, hardening, regression, and release-readiness. This is the Codex-native replacement for the original Claude Code `/team-polish` workflow.
+metadata:
+  short-description: Coordinate a polish pass
+---
+
+# Codex Game Studios Team Polish
+
+This skill coordinates a release-quality polish pass. Do not spawn subagents
+unless the user explicitly asks for delegation or parallel agent work.
+
+## Required Input
+
+Require the feature or area to polish, such as `combat`, `main menu`,
+`inventory system`, or `level-1`. If missing, ask for it.
+
+## Roles To Simulate Or Delegate
+
+- Performance analyst: profiling, budgets, memory, frame time.
+- Engine programmer: low-level rendering, loading, allocation issues.
+- Technical artist: VFX quality, shader optimization, visual readability.
+- Sound designer: feedback sounds, mix, ambience, spatial audio.
+- Tools programmer: pipeline/editor tooling when content tools are involved.
+- QA tester: edge cases, regression, soak/stress evidence.
+
+## Inputs To Read
+
+- Target GDDs, UX specs, art bible, audio docs, and acceptance criteria.
+- `.claude/docs/technical-preferences.md`.
+- Performance budgets and prior `production/qa/` reports.
+- Existing source/assets/audio/tests for the target area.
+- `docs/tech-debt-register.md`, if present.
+- Original source workflow, only if more detail is needed:
+  `.claude/skills/team-polish/SKILL.md`.
+
+## Pipeline
+
+1. Assessment: run or follow `cgs-perf-profile`, identify bottlenecks, visual
+   gaps, audio gaps, tool risks, and QA risks.
+2. Optimization: address high-priority hotspots without changing gameplay
+   behavior. Capture before/after metrics when evidence exists.
+3. Visual polish: improve feedback clarity, VFX consistency, graceful quality
+   scaling, and art bible alignment.
+4. Audio polish: validate missing events, mix balance, ambience, spatialization,
+   and audio routing.
+5. Tools check: verify editor/content pipeline stability if the polished area
+   depends on custom tools.
+6. Hardening: define or run regression, edge-case, stress, and soak checks.
+7. Sign-off: report `READY FOR RELEASE` or `NEEDS MORE WORK`.
+
+## Safety
+
+- Do not treat subjective polish as permission for broad redesign.
+- Ask before changing design direction, large asset sets, or multi-file
+  architecture.
+- Keep changes traceable to release-readiness issues, player feedback, or
+  documented quality targets.
+
+## Completion
+
+Finish with:
+
+- Target area.
+- Performance before/after evidence or required profiling.
+- Visual and audio polish status.
+- QA hardening status.
+- Remaining issues and severity.
+- Release-readiness verdict.
+- Next request: release checklist, gate check, sprint plan update, or another
+  targeted polish pass.

--- a/.agents/skills/cgs-team-qa/SKILL.md
+++ b/.agents/skills/cgs-team-qa/SKILL.md
@@ -1,0 +1,71 @@
+---
+name: cgs-team-qa
+description: Use to coordinate a Codex Game Studios QA cycle for a sprint or feature, including strategy, smoke gate, test plan, manual QA package, bug routing, and sign-off. This is the Codex-native replacement for the original Claude Code `/team-qa` workflow.
+metadata:
+  short-description: Coordinate a QA cycle
+---
+
+# Codex Game Studios Team QA
+
+This skill coordinates QA strategy and sign-off. Codex may prepare plans,
+cases, reports, and bug records, but human-run manual QA must be reported as
+evidence; do not claim it was executed unless evidence is provided.
+
+Do not spawn subagents unless the user explicitly asks for delegation or
+parallel agent work.
+
+## Scope
+
+- `sprint`: current sprint from `production/sprint-status.yaml`.
+- `feature: [system-name]`: stories and tests for one system.
+- Explicit sprint or story paths.
+
+If scope is missing, infer from session/sprint state only when unambiguous;
+otherwise ask.
+
+## Inputs To Read
+
+- `production/session-state/active.md`, if present.
+- `production/sprint-status.yaml` and `production/sprints/*.md`.
+- In-scope `production/epics/**/*.md` stories.
+- Relevant GDD acceptance criteria.
+- Existing QA plans, smoke reports, bugs, and test evidence.
+- `tests/smoke/`, `tests/`, and `tests/regression-suite.md`.
+- Original source workflow, only if more detail is needed:
+  `.claude/skills/team-qa/SKILL.md`.
+
+## Pipeline
+
+1. Load context: identify scope, story count, stage, current build/test status.
+2. QA strategy: classify each story as Logic, Integration, Visual/Feel, UI, or
+   Config/Data. Identify automated and manual evidence requirements.
+3. Smoke gate: produce `PASS`, `PASS WITH WARNINGS`, or `FAIL`. If smoke fails,
+   stop and report blockers.
+4. Test plan: create a plan covering scope, story table, automation needs,
+   manual QA scope, entry criteria, exit criteria, and out-of-scope areas. Ask
+   before writing `production/qa/qa-plan-[scope]-[date].md`.
+5. Test cases: draft manual cases with preconditions, steps, expected result,
+   actual result field, and pass/fail field.
+6. Bug routing: when failure evidence is provided, create or update bug reports
+   under `production/qa/bugs/` after approval.
+7. Sign-off: create `APPROVED`, `APPROVED WITH CONDITIONS`, or `NOT APPROVED`
+   verdict. Ask before writing `production/qa/qa-signoff-[scope]-[date].md`.
+
+## Verdict Rules
+
+- `APPROVED`: all in-scope stories have adequate evidence and no open S1/S2
+  bugs.
+- `APPROVED WITH CONDITIONS`: only S3/S4 issues remain or notes are documented.
+- `NOT APPROVED`: any S1/S2 bug remains, key evidence is missing, or stories
+  fail without workaround.
+
+## Completion
+
+Finish with:
+
+- Scope and story count.
+- Smoke gate result.
+- Manual and automated evidence status.
+- Bugs filed or required.
+- Final QA verdict.
+- Next request: gate check, bug triage, evidence review, or targeted QA rerun.

--- a/.agents/skills/cgs-team-release/SKILL.md
+++ b/.agents/skills/cgs-team-release/SKILL.md
@@ -1,0 +1,80 @@
+---
+name: cgs-team-release
+description: Use to coordinate a Codex Game Studios release from version planning through release candidate, quality gates, go/no-go, deployment checklist, communication, and post-release monitoring. This is the Codex-native replacement for the original Claude Code `/team-release` workflow.
+metadata:
+  short-description: Coordinate a release
+---
+
+# Codex Game Studios Team Release
+
+This skill coordinates release work. It must not tag, deploy, publish, or merge
+release changes without explicit user approval.
+
+Do not spawn subagents unless the user explicitly asks for delegation or
+parallel agent work.
+
+## Version
+
+Require a version number or infer it from milestone/session files. If no version
+is discoverable, ask for one. Do not default to a hardcoded version.
+
+## Roles To Simulate Or Delegate
+
+- Producer: release authorization and go/no-go.
+- Release manager: branch, versioning, checklist, changelog.
+- QA lead: regression, bug severity, quality sign-off.
+- DevOps engineer: build artifacts, CI, deployment readiness.
+- Security engineer: online/multiplayer/player-data risk.
+- Analytics engineer: telemetry events and dashboards.
+- Community manager: patch notes and announcement readiness.
+- Network programmer: multiplayer stability, if applicable.
+
+## Inputs To Read
+
+- `production/session-state/active.md`.
+- `production/milestones/`, release docs, and sprint status.
+- `production/qa/` sign-off reports, bugs, smoke/regression results.
+- `docs/`, ADRs, security notes, and telemetry docs.
+- Build/deployment scripts and CI config.
+- `CHANGELOG.md` or existing release notes.
+- Original source workflow, only if more detail is needed:
+  `.claude/skills/team-release/SKILL.md`.
+
+## Pipeline
+
+1. Release planning: confirm scope, deferred items, target date, and release
+   authorization.
+2. Release candidate: identify candidate commit/branch, version files, and
+   release checklist needs. Ask before editing version files or branches.
+3. Quality gate: verify regression status, open S1/S2 bugs, artifact builds,
+   CI status, security needs, and multiplayer stability if relevant.
+4. Localization, performance, analytics: check string status, perf budgets, and
+   telemetry readiness.
+5. Go/no-go: produce `GO`, `GO WITH CONDITIONS`, or `NO-GO` with rationale. If
+   `NO-GO`, stop before tagging or deployment.
+6. Deployment preparation: only with explicit approval, prepare changelog,
+   patch notes, staging smoke plan, release tag checklist, and rollback plan.
+7. Post-release: define 48-hour monitoring, bug triage, community monitoring,
+   analytics checks, and retrospective triggers.
+
+## Hard Stops
+
+Stop before release execution if:
+
+- S1/S2 bugs are open.
+- Required QA sign-off is missing.
+- Build artifacts are missing or unreproducible.
+- Security or network blockers exist for online/multiplayer features.
+- User has not explicitly approved tag/deploy/publish actions.
+
+## Completion
+
+Finish with:
+
+- Version and candidate source.
+- Scope and deferred items.
+- Quality gate results.
+- Go/no-go verdict.
+- Release artifacts/checklists status.
+- Deployment and monitoring plan.
+- Next request: release checklist, changelog, patch notes, or hotfix planning.

--- a/.agents/skills/cgs-team-ui/SKILL.md
+++ b/.agents/skills/cgs-team-ui/SKILL.md
@@ -1,0 +1,72 @@
+---
+name: cgs-team-ui
+description: Use to coordinate a Codex Game Studios UI feature through UX spec, visual design, engine implementation, accessibility review, and polish. This is the Codex-native replacement for the original Claude Code `/team-ui` workflow.
+metadata:
+  short-description: Coordinate UI feature work
+---
+
+# Codex Game Studios Team UI
+
+This skill runs a full UI feature pipeline. In Codex, do not spawn subagents
+unless the user explicitly asks for delegation or parallel agent work. Otherwise
+coordinate the role perspectives locally.
+
+## Required Input
+
+Require a UI feature description, screen, flow, HUD area, or interaction
+pattern. If missing, ask for the target.
+
+## Roles To Simulate Or Delegate
+
+- UX design: flow, wireframe, accessibility, input behavior.
+- UI programming: screen/widget structure, data binding, events.
+- Art direction: visual treatment, consistency, asset requirements.
+- Engine UI specialist: engine-native UI framework and pitfalls.
+- Accessibility specialist: committed tier compliance and blockers.
+
+## Inputs To Read
+
+- `design/gdd/game-concept.md`.
+- `design/player-journey.md`, if present.
+- Relevant GDD UI Requirements sections.
+- `design/ux/interaction-patterns.md`, if present.
+- `design/accessibility-requirements.md`, if present.
+- `design/art/` or art bible files.
+- `.claude/docs/technical-preferences.md`.
+- Existing UI source and tests.
+- Original source workflow, only if more detail is needed:
+  `.claude/skills/team-ui/SKILL.md`.
+
+## Pipeline
+
+1. Context: summarize player state, supported platforms, existing patterns,
+   accessibility tier, and UI constraints.
+2. UX spec: run or follow `cgs-ux-design` for the target. If designing HUD, use
+   HUD-specific structure. Ask before writing new UX files.
+3. UX review: run or follow `cgs-ux-review`; do not proceed past major blockers
+   unless the user explicitly accepts the risk.
+4. Visual design: derive style, layout, motion, and asset needs from the art
+   bible while preserving accessibility.
+5. Engine implementation: choose engine-native UI patterns. UI must display
+   state and emit events; it must not own gameplay state.
+6. Review: verify wireframe match, input navigation, visual consistency,
+   localization readiness, and accessibility.
+7. Polish: handle motion reduction, aspect ratios, UI audio routing, and update
+   interaction patterns if new ones were introduced.
+
+## Missing Pattern Library
+
+If `design/ux/interaction-patterns.md` is missing, surface the gap and ask
+whether to create it first or proceed while documenting any new patterns.
+
+## Completion
+
+Finish with:
+
+- UX spec status and review verdict.
+- Visual design and asset status.
+- Implementation status.
+- Accessibility and input method status.
+- Interaction pattern library status.
+- Open blockers and recommended next request: UX review, code review, or team
+  polish.

--- a/.agents/skills/cgs-test-evidence-review/SKILL.md
+++ b/.agents/skills/cgs-test-evidence-review/SKILL.md
@@ -1,0 +1,72 @@
+---
+name: cgs-test-evidence-review
+description: Use to review Codex Game Studios automated and manual test evidence for stories, sprints, or systems and decide whether acceptance criteria are genuinely covered. This is the Codex-native replacement for the original Claude Code `/test-evidence-review` workflow.
+metadata:
+  short-description: Review test evidence quality
+---
+
+# Codex Game Studios Test Evidence Review
+
+This skill evaluates evidence quality, not just file existence. It is read-only
+by default.
+
+## Modes
+
+- `story-path [path]`: review one story and its evidence.
+- `sprint`: review the current sprint.
+- `system [name]`: review one gameplay/system area.
+
+If the target is ambiguous, ask for the story, sprint, or system name.
+
+## Inputs To Read
+
+- `production/sprint-status.yaml` and latest `production/sprints/*.md`.
+- `production/epics/**/*.md` stories and `EPIC.md` files.
+- Referenced GDD Acceptance Criteria, Formulas, and Edge Cases.
+- `tests/**/*`, test result logs, and manual QA evidence under `production/qa/`.
+- `docs/architecture/tr-registry.yaml`, if present.
+- Original source workflow, only if more detail is needed:
+  `.claude/skills/test-evidence-review/SKILL.md`.
+
+## Review Criteria
+
+For each story or acceptance criterion, check:
+
+- Automated assertions verify behavior, not only construction or happy paths.
+- Edge cases and error paths are covered when the GDD requires them.
+- Formula tests trace back to documented formulas and expected values.
+- Manual evidence has steps, result, date, build/version, tester, and artifacts.
+- Evidence is fresh enough for the changed code or current sprint.
+- Test names and paths make coverage discoverable.
+- Visual/feel criteria have appropriate screenshots, videos, or signed notes.
+
+## Verdicts
+
+Use one verdict per story and per major criterion:
+
+- `ADEQUATE`: evidence is specific, current, and linked to requirements.
+- `INCOMPLETE`: evidence exists but misses important criteria or freshness.
+- `MISSING`: no credible evidence was found.
+
+Do not mark evidence as adequate only because a test file exists.
+
+## Write Output
+
+Default output is a findings table in the response. If the user asks for a
+persisted report, or after approval, create:
+
+```text
+production/qa/evidence-review-[date].md
+```
+
+Do not modify tests or stories from this skill unless the user explicitly asks
+for a separate implementation pass.
+
+## Completion
+
+Finish with:
+
+- Overall evidence verdict.
+- Highest-risk missing evidence.
+- Stories blocked by evidence gaps.
+- Recommended next action: add tests, collect manual evidence, or run bug triage.

--- a/.agents/skills/cgs-test-flakiness/SKILL.md
+++ b/.agents/skills/cgs-test-flakiness/SKILL.md
@@ -1,0 +1,82 @@
+---
+name: cgs-test-flakiness
+description: Use to detect, classify, and report flaky tests in Codex Game Studios from CI logs, test history, or the regression registry without deleting tests. This is the Codex-native replacement for the original Claude Code `/test-flakiness` workflow.
+metadata:
+  short-description: Detect flaky tests
+---
+
+# Codex Game Studios Test Flakiness
+
+This skill finds tests with inconsistent outcomes and recommends quarantine,
+fix, or monitoring actions. It must never delete tests.
+
+## Modes
+
+- `[ci-log-path]`: parse one CI or local test log.
+- `scan`: inspect available test result files and recent logs.
+- `registry`: inspect `tests/regression-suite.md` and related QA notes.
+
+If no mode is provided, start with `scan` using local artifacts only.
+
+## Inputs To Read
+
+- User-provided CI log path.
+- `test-results/`, `coverage/`, `production/qa/`, and recent test logs if
+  present.
+- `tests/regression-suite.md`.
+- Existing test files for named failures.
+- Original source workflow, only if more detail is needed:
+  `.claude/skills/test-flakiness/SKILL.md`.
+
+## Detection
+
+Look for:
+
+- Same test name with both pass and fail outcomes.
+- Retry success after initial failure.
+- Timeout or order-dependent failures.
+- Random seed, clock, async, scene-load, resource, network, or external-state
+  clues.
+- Floating-point threshold failures or performance budget variance.
+
+Classify likely cause as one of:
+
+- Timing/async race.
+- Order dependency.
+- Random seed or nondeterministic data.
+- Resource leak or shared state.
+- External service or file-system dependency.
+- Floating-point tolerance.
+- Scene or asset load race.
+- Unknown, needs reproduction.
+
+## Recommendations
+
+For each flaky candidate, recommend:
+
+- `FIX`: clear root cause and safe fix path.
+- `QUARANTINE`: high noise or blocking CI, with owner and exit criteria.
+- `MONITOR`: weak evidence or low impact.
+
+Quarantine is a temporary risk-control action, not a replacement for fixing the
+test.
+
+## Write Output
+
+Default output is a report in the response. Ask before editing:
+
+- `tests/regression-suite.md` quarantine or notes section.
+- `production/qa/flakiness-report-[date].md`.
+
+Never remove or skip a test without explicit user approval and a documented
+reason.
+
+## Completion
+
+Finish with:
+
+- Flaky tests found.
+- Evidence source.
+- Likely cause.
+- Recommended action and owner placeholder.
+- Follow-up command or Codex request to fix the highest-priority flaky test.

--- a/README.md
+++ b/README.md
@@ -206,6 +206,11 @@ live in `.agents/skills/`:
 - `cgs-reverse-document` — generate docs from existing implementation
 - `cgs-localize` — localization pipeline workflows
 - `cgs-onboard` — role/area onboarding document generation
+- `cgs-team-combat` — coordinate combat feature delivery
+- `cgs-team-ui` — coordinate UI feature delivery
+- `cgs-team-qa` — coordinate QA cycles and sign-off
+- `cgs-team-release` — coordinate release readiness and deployment planning
+- `cgs-team-polish` — coordinate release-quality polish passes
 
 In Codex, use natural-language requests instead of Claude Code slash commands:
 
@@ -269,6 +274,11 @@ Propagate design changes from design/gdd/combat.md.
 Reverse-document design from src/gameplay/combat.
 Run localization status.
 Create onboarding for a new QA contributor.
+Coordinate a combat team pass for a melee parry system.
+Coordinate a UI team pass for the inventory screen.
+Coordinate QA for the current sprint.
+Coordinate release readiness for version 0.3.0.
+Coordinate a polish pass for combat feel.
 ```
 
 The original Claude Code workflows remain available under `.claude/` as source

--- a/README.md
+++ b/README.md
@@ -171,6 +171,11 @@ live in `.agents/skills/`:
 - `cgs-regression-suite` — audit and maintain regression coverage
 - `cgs-test-setup` — scaffold engine-specific test infrastructure
 - `cgs-test-helpers` — generate test helper utilities
+- `cgs-soak-test` — create extended play soak test protocols
+- `cgs-test-evidence-review` — evaluate automated and manual test evidence
+- `cgs-test-flakiness` — detect and classify flaky tests
+- `cgs-skill-test` — validate repo-local Codex skills
+- `cgs-skill-improve` — improve one Codex skill with a test-fix-retest loop
 - `cgs-release-checklist` — pre-release validation checklist
 - `cgs-launch-checklist` — full launch readiness checklist
 - `cgs-changelog` — internal and player-facing changelog generation
@@ -229,6 +234,11 @@ Run a smoke check for the current sprint.
 Audit the regression suite.
 Set up tests for the configured engine.
 Create test helpers for the combat system.
+Create a 2h soak test protocol focused on stability.
+Review test evidence for the current sprint.
+Scan test logs for flaky tests.
+Validate all Codex Game Studios skills.
+Improve the cgs-qa-plan skill.
 Generate a release checklist for PC.
 Run a dry-run launch checklist for July 15.
 Generate the changelog for version 0.3.0.

--- a/README.md
+++ b/README.md
@@ -26,9 +26,10 @@
 > upstream `.claude/` assets as source material while adding Codex-readable
 > instructions such as `AGENTS.md`.
 
-> **Porting status:** Early migration. Claude Code workflows are still present.
-> Codex-native instructions have started with `AGENTS.md` and
-> `docs/CODEX-PORTING.md`.
+> **Porting status:** The original 72 workflow skills now have repo-local Codex
+> ports under `.agents/skills/`. Claude Code assets remain available under
+> `.claude/` as upstream source material while agents, hooks, and rules continue
+> to be adapted for Codex.
 
 ## Why This Exists
 
@@ -144,11 +145,12 @@ Type `/` in Claude Code to access all 72 skills:
 
 ## Codex Usage
 
-This fork is being ported to Codex incrementally. The first Codex-native skills
-live in `.agents/skills/`:
+This fork provides repo-local Codex skills in `.agents/skills/`:
 
 - `cgs-start` — first-time onboarding and workflow routing
 - `cgs-help` — read-only "what should I do next?" guidance
+- `cgs-project-stage-detect` — read-only project stage and gap detection
+- `cgs-adopt` — brownfield template adoption audit
 - `cgs-setup-engine` — engine, language, platform, and standards setup
 - `cgs-brainstorm` — concept ideation into `design/gdd/game-concept.md`
 - `cgs-map-systems` — systems decomposition into `design/gdd/systems-index.md`
@@ -166,6 +168,7 @@ live in `.agents/skills/`:
 - `cgs-story-readiness` — check if stories are implementation-ready
 - `cgs-code-review` — implementation code review
 - `cgs-sprint-plan` — create, update, or summarize sprint plans
+- `cgs-sprint-status` — fast read-only sprint progress snapshot
 - `cgs-qa-plan` — generate sprint/feature/story QA plans
 - `cgs-smoke-check` — smoke readiness gate before QA handoff
 - `cgs-regression-suite` — audit and maintain regression coverage
@@ -181,6 +184,7 @@ live in `.agents/skills/`:
 - `cgs-changelog` — internal and player-facing changelog generation
 - `cgs-patch-notes` — public patch notes drafting
 - `cgs-hotfix` — emergency S1/S2 hotfix workflow
+- `cgs-day-one-patch` — launch day-one patch planning
 - `cgs-milestone-review` — milestone progress and go/no-go review
 - `cgs-retrospective` — sprint or milestone retrospective
 - `cgs-bug-report` — bug filing, verification, and closure workflow
@@ -211,12 +215,18 @@ live in `.agents/skills/`:
 - `cgs-team-qa` — coordinate QA cycles and sign-off
 - `cgs-team-release` — coordinate release readiness and deployment planning
 - `cgs-team-polish` — coordinate release-quality polish passes
+- `cgs-team-audio` — coordinate audio feature delivery
+- `cgs-team-level` — coordinate level or area design
+- `cgs-team-live-ops` — coordinate seasons and live events
+- `cgs-team-narrative` — coordinate narrative content delivery
 
 In Codex, use natural-language requests instead of Claude Code slash commands:
 
 ```text
 Start Codex Game Studios onboarding.
 What should I do next in this game project?
+Detect the current project stage.
+Audit this existing project for Codex Game Studios adoption.
 Configure this project for Godot 4.6 with GDScript.
 Brainstorm a game concept from this seed: cozy space salvaging.
 Map the systems for the current game concept.
@@ -234,6 +244,7 @@ Generate the control manifest from accepted ADRs.
 Check readiness for all stories in the current sprint.
 Review the files changed by the current story.
 Create a new sprint plan from ready Foundation stories.
+Show sprint status.
 Generate a QA plan for the current sprint.
 Run a smoke check for the current sprint.
 Audit the regression suite.
@@ -249,6 +260,7 @@ Run a dry-run launch checklist for July 15.
 Generate the changelog for version 0.3.0.
 Write detailed patch notes for version 0.3.0.
 Start a hotfix workflow for BUG-142.
+Plan a day-one patch for version 1.0.0.
 Review the current milestone.
 Create a retrospective for sprint 3.
 File a bug report for this crash description.
@@ -279,6 +291,10 @@ Coordinate a UI team pass for the inventory screen.
 Coordinate QA for the current sprint.
 Coordinate release readiness for version 0.3.0.
 Coordinate a polish pass for combat feel.
+Coordinate audio design for the forest biome.
+Coordinate level design for the tutorial area.
+Coordinate a live-ops event for winter festival.
+Coordinate narrative work for the boss intro scene.
 ```
 
 The original Claude Code workflows remain available under `.claude/` as source

--- a/docs/CODEX-PORTING.md
+++ b/docs/CODEX-PORTING.md
@@ -9,7 +9,7 @@ license and attribution.
 - Original Claude Code assets remain under `.claude/`.
 - Codex entry instructions exist in `AGENTS.md`.
 - Directory-scoped Codex instructions exist in `src/`, `design/`, and `docs/`.
-- 59 repo-local Codex skills exist in `.agents/skills/`.
+- 64 repo-local Codex skills exist in `.agents/skills/`.
 - Ported starter workflows: `cgs-start`, `cgs-help`, `cgs-setup-engine`,
   `cgs-brainstorm`, `cgs-map-systems`, `cgs-design-system`,
   `cgs-design-review`, `cgs-gate-check`, `cgs-dev-story`,
@@ -30,7 +30,9 @@ license and attribution.
   `cgs-asset-audit`, `cgs-content-audit`, `cgs-consistency-check`,
   `cgs-balance-check`, `cgs-ux-design`, `cgs-ux-review`,
   `cgs-review-all-gdds`, `cgs-propagate-design-change`,
-  `cgs-reverse-document`, `cgs-localize`, and `cgs-onboard`.
+  `cgs-reverse-document`, `cgs-localize`, `cgs-onboard`,
+  `cgs-team-combat`, `cgs-team-ui`, `cgs-team-qa`, `cgs-team-release`,
+  and `cgs-team-polish`.
 - `.codex` is treated as a local Codex runtime file and ignored by Git.
 
 ## Porting Principles
@@ -108,6 +110,6 @@ team orchestration, release, and utility.
 
 ## Next Concrete Step
 
-Port the next team orchestration workflows: `team-combat`, `team-ui`,
-`team-qa`, `team-release`, and `team-polish`. Preserve the original intent while
-rewriting delegation assumptions for Codex's explicit subagent policy.
+Port the remaining team orchestration workflows: `team-audio`, `team-level`,
+`team-live-ops`, and `team-narrative`. Then finish the utility workflows:
+`project-stage-detect`, `sprint-status`, `adopt`, and `day-one-patch`.

--- a/docs/CODEX-PORTING.md
+++ b/docs/CODEX-PORTING.md
@@ -9,20 +9,22 @@ license and attribution.
 - Original Claude Code assets remain under `.claude/`.
 - Codex entry instructions exist in `AGENTS.md`.
 - Directory-scoped Codex instructions exist in `src/`, `design/`, and `docs/`.
-- 64 repo-local Codex skills exist in `.agents/skills/`.
-- Ported starter workflows: `cgs-start`, `cgs-help`, `cgs-setup-engine`,
+- 72 repo-local Codex skills exist in `.agents/skills/`.
+- Ported starter workflows: `cgs-start`, `cgs-help`,
+  `cgs-project-stage-detect`, `cgs-adopt`, `cgs-setup-engine`,
   `cgs-brainstorm`, `cgs-map-systems`, `cgs-design-system`,
   `cgs-design-review`, `cgs-gate-check`, `cgs-dev-story`,
   `cgs-create-architecture`, `cgs-architecture-decision`,
   `cgs-create-epics`, `cgs-create-stories`, `cgs-story-done`,
   `cgs-architecture-review`, `cgs-create-control-manifest`,
   `cgs-story-readiness`, `cgs-code-review`, `cgs-sprint-plan`,
+  `cgs-sprint-status`,
   `cgs-qa-plan`, `cgs-smoke-check`, `cgs-regression-suite`,
   `cgs-test-setup`, `cgs-test-helpers`, `cgs-soak-test`,
   `cgs-test-evidence-review`, `cgs-test-flakiness`, `cgs-skill-test`,
   `cgs-skill-improve`, `cgs-release-checklist`,
-  `cgs-launch-checklist`, `cgs-changelog`, `cgs-patch-notes`, and
-  `cgs-hotfix`, `cgs-milestone-review`, `cgs-retrospective`,
+  `cgs-launch-checklist`, `cgs-changelog`, `cgs-patch-notes`,
+  `cgs-hotfix`, `cgs-day-one-patch`, `cgs-milestone-review`, `cgs-retrospective`,
   `cgs-bug-report`, `cgs-bug-triage`, `cgs-playtest-report`,
   `cgs-scope-check`, `cgs-estimate`, `cgs-perf-profile`,
   `cgs-security-audit`, `cgs-tech-debt`, `cgs-quick-design`,
@@ -32,7 +34,8 @@ license and attribution.
   `cgs-review-all-gdds`, `cgs-propagate-design-change`,
   `cgs-reverse-document`, `cgs-localize`, `cgs-onboard`,
   `cgs-team-combat`, `cgs-team-ui`, `cgs-team-qa`, `cgs-team-release`,
-  and `cgs-team-polish`.
+  `cgs-team-polish`, `cgs-team-audio`, `cgs-team-level`,
+  `cgs-team-live-ops`, and `cgs-team-narrative`.
 - `.codex` is treated as a local Codex runtime file and ignored by Git.
 
 ## Porting Principles
@@ -110,6 +113,7 @@ team orchestration, release, and utility.
 
 ## Next Concrete Step
 
-Port the remaining team orchestration workflows: `team-audio`, `team-level`,
-`team-live-ops`, and `team-narrative`. Then finish the utility workflows:
-`project-stage-detect`, `sprint-status`, `adopt`, and `day-one-patch`.
+The original 72 Claude Code skills now have repo-local Codex skill ports. Next,
+reconcile remaining README sections that still describe Claude Code as the
+primary interface, convert the 49 original agent files into compact Codex role
+references, and decide whether to package the Codex port as a plugin.

--- a/docs/CODEX-PORTING.md
+++ b/docs/CODEX-PORTING.md
@@ -9,7 +9,7 @@ license and attribution.
 - Original Claude Code assets remain under `.claude/`.
 - Codex entry instructions exist in `AGENTS.md`.
 - Directory-scoped Codex instructions exist in `src/`, `design/`, and `docs/`.
-- Initial repo-local Codex skills exist in `.agents/skills/`.
+- 59 repo-local Codex skills exist in `.agents/skills/`.
 - Ported starter workflows: `cgs-start`, `cgs-help`, `cgs-setup-engine`,
   `cgs-brainstorm`, `cgs-map-systems`, `cgs-design-system`,
   `cgs-design-review`, `cgs-gate-check`, `cgs-dev-story`,
@@ -18,7 +18,9 @@ license and attribution.
   `cgs-architecture-review`, `cgs-create-control-manifest`,
   `cgs-story-readiness`, `cgs-code-review`, `cgs-sprint-plan`,
   `cgs-qa-plan`, `cgs-smoke-check`, `cgs-regression-suite`,
-  `cgs-test-setup`, `cgs-test-helpers`, `cgs-release-checklist`,
+  `cgs-test-setup`, `cgs-test-helpers`, `cgs-soak-test`,
+  `cgs-test-evidence-review`, `cgs-test-flakiness`, `cgs-skill-test`,
+  `cgs-skill-improve`, `cgs-release-checklist`,
   `cgs-launch-checklist`, `cgs-changelog`, `cgs-patch-notes`, and
   `cgs-hotfix`, `cgs-milestone-review`, `cgs-retrospective`,
   `cgs-bug-report`, `cgs-bug-triage`, `cgs-playtest-report`,
@@ -106,6 +108,6 @@ team orchestration, release, and utility.
 
 ## Next Concrete Step
 
-Port the next QA utility workflows: `soak-test`, `test-evidence-review`,
-`test-flakiness`, `skill-test`, and `skill-improve`. Keep each skill concise and
-load original `.claude/` source material only when needed.
+Port the next team orchestration workflows: `team-combat`, `team-ui`,
+`team-qa`, `team-release`, and `team-polish`. Preserve the original intent while
+rewriting delegation assumptions for Codex's explicit subagent policy.


### PR DESCRIPTION
## Summary
- Port the remaining QA utility, team orchestration, and utility workflows into repo-local Codex skills under .agents/skills/
- Bring the Codex skill catalog to parity with the original 72 Claude Code workflows
- Update README and docs/CODEX-PORTING.md to reflect completed skill catalog port status

## Validation
- find .agents/skills -maxdepth 2 -name SKILL.md -print | wc -l => 72
- rg --files-without-match "short-description:" .agents/skills/*/SKILL.md => no missing files
- bash -n .claude/hooks/*.sh
- python3 -m json.tool .claude/settings.json