### PR TITLE
Add Codex role references

### DIFF
--- a/.agents/roles/README.md
+++ b/.agents/roles/README.md
@@ -1,0 +1,32 @@
+# Codex Role References
+
+This directory contains compact Codex-oriented references for the 49 original
+Claude Code Game Studios agent roles.
+
+Use these files as role lenses for analysis, review, and implementation. They
+do not guarantee that a same-named Codex subagent exists. Only use subagents
+when the user explicitly asks for delegation or parallel agent work; otherwise
+apply the relevant role guidance locally.
+
+## Navigation
+
+- `directors.md`: 3 top-level decision and coordination roles.
+- `department-leads.md`: 8 discipline leads.
+- `specialists.md`: 23 non-engine implementation and content specialists.
+- `engine-specialists.md`: 15 Godot, Unity, and Unreal specialists.
+
+## Source Mapping
+
+Each role maps back to one upstream file in `.claude/agents/[role].md`. Read the
+upstream file only when you need full original detail; keep normal Codex context
+small by starting with these compact references.
+
+## Delegation Policy
+
+- Default: use the role reference to structure your own reasoning and output.
+- If the user explicitly requests delegation or parallel agent work, create
+  concrete bounded subtasks and provide the relevant role context.
+- Do not claim that Claude Code tools, `subagent_type`, or the original agent
+  roster are available in Codex.
+- For design direction, architecture, and multi-file rewrites, preserve user
+  control and ask before locking decisions.

--- a/.agents/roles/department-leads.md
+++ b/.agents/roles/department-leads.md
@@ -1,0 +1,24 @@
+# Department Lead Roles
+
+Department leads own discipline standards and review quality for their area.
+Use them to shape plans, audits, and sign-off criteria.
+
+| Role | Use When | Codex Guidance | Source |
+| --- | --- | --- | --- |
+| `game-designer` | Mechanics, core loops, progression, combat rules, economy rules, or player-facing systems need design. | Define rules, formulas, edge cases, tuning knobs, and acceptance criteria before implementation. | `.claude/agents/game-designer.md` |
+| `lead-programmer` | Code architecture, API design, refactoring strategy, code review, or programming task breakdown is needed. | Enforce ADRs, interfaces, testability, layering, and engine-safe implementation patterns. | `.claude/agents/lead-programmer.md` |
+| `art-director` | Visual identity, art bible, asset standards, color, UI visual direction, or art pipeline decisions are needed. | Anchor recommendations in art bible/pillars, asset budgets, readability, and production feasibility. | `.claude/agents/art-director.md` |
+| `audio-director` | Sonic identity, music direction, audio palette, mix strategy, or audio architecture decisions are needed. | Define emotion, priority, mix targets, adaptive rules, and audio accessibility constraints. | `.claude/agents/audio-director.md` |
+| `narrative-director` | Story architecture, character arcs, world rules, dialogue strategy, or narrative systems need direction. | Preserve canon, voice, pacing, lore consistency, and documented true answers for mysteries. | `.claude/agents/narrative-director.md` |
+| `qa-lead` | Test strategy, bug severity, regression planning, release gates, or QA process decisions are needed. | Classify risk, define evidence requirements, and produce clear PASS/CONCERNS/FAIL-style gates. | `.claude/agents/qa-lead.md` |
+| `release-manager` | Release planning, certification, store submission, versioning, or release-day coordination is needed. | Require checklists, rollback thinking, platform constraints, QA sign-off, and explicit go/no-go. | `.claude/agents/release-manager.md` |
+| `localization-lead` | Internationalization, string extraction, locale testing, translation workflow, or text quality is needed. | Enforce string keys, placeholders, expansion headroom, locale-specific risks, and translator context. | `.claude/agents/localization-lead.md` |
+
+## Lead Review Pattern
+
+For discipline decisions, summarize:
+
+- Applicable docs and constraints.
+- Options and trade-offs.
+- Recommended path.
+- Required sign-off or follow-up evidence.

--- a/.agents/roles/directors.md
+++ b/.agents/roles/directors.md
@@ -1,0 +1,17 @@
+# Director Roles
+
+Director roles handle cross-discipline decisions, project-level risk, and phase
+alignment. They should shape recommendations, not override the user.
+
+| Role | Use When | Codex Guidance | Source |
+| --- | --- | --- | --- |
+| `creative-director` | A decision affects game identity, pillars, tone, aesthetics, narrative direction, or multiple creative departments disagree. | Present 2-3 strategic options with trade-offs, recommend one, and ask before locking vision changes. | `.claude/agents/creative-director.md` |
+| `technical-director` | A decision affects engine architecture, technology choices, performance strategy, cross-system constraints, or technical risk. | Validate against ADRs, engine reference docs, and long-term maintainability. Escalate unresolved architecture conflicts. | `.claude/agents/technical-director.md` |
+| `producer` | Work needs planning, prioritization, scope negotiation, milestone tracking, or multi-department coordination. | Convert ambiguity into concrete scope, owners, risks, next actions, and phase-gate readiness. | `.claude/agents/producer.md` |
+
+## Escalation
+
+- Creative conflicts: use `creative-director`.
+- Technical conflicts: use `technical-director`.
+- Schedule, scope, or ownership conflicts: use `producer`.
+- User decisions remain final.

--- a/.agents/roles/engine-specialists.md
+++ b/.agents/roles/engine-specialists.md
@@ -1,0 +1,34 @@
+# Engine Specialist Roles
+
+Engine specialists validate engine-specific patterns, APIs, asset pipelines, and
+performance risks. Check `docs/engine-reference/` before relying on engine APIs.
+
+## Godot
+
+| Role | Use When | Codex Guidance | Source |
+| --- | --- | --- | --- |
+| `godot-specialist` | Godot architecture, node/scene structure, signals, resources, engine APIs, or optimization. | Validate patterns against the pinned Godot version and project language choice. | `.claude/agents/godot-specialist.md` |
+| `godot-gdscript-specialist` | GDScript typing, signals, coroutines, patterns, and performance. | Enforce static typing where useful, idiomatic signals, and clear node ownership. | `.claude/agents/godot-gdscript-specialist.md` |
+| `godot-csharp-specialist` | Godot C#/.NET patterns, exports, signal delegates, async, and type-safe node access. | Keep C# idiomatic to both .NET and Godot 4. | `.claude/agents/godot-csharp-specialist.md` |
+| `godot-gdextension-specialist` | GDExtension, native code, C++/Rust bindings, custom nodes, or performance-critical native work. | Keep native boundaries clean and justify native complexity with performance evidence. | `.claude/agents/godot-gdextension-specialist.md` |
+| `godot-shader-specialist` | Godot shaders, materials, particles, post-processing, or rendering customization. | Balance shader quality with Godot renderer constraints and target hardware. | `.claude/agents/godot-shader-specialist.md` |
+
+## Unity
+
+| Role | Use When | Codex Guidance | Source |
+| --- | --- | --- | --- |
+| `unity-specialist` | Unity architecture, subsystems, MonoBehaviour vs DOTS, Input System, UI Toolkit, or optimization. | Validate against pinned Unity version and chosen render pipeline. | `.claude/agents/unity-specialist.md` |
+| `unity-dots-specialist` | ECS, Jobs, Burst, hybrid renderer, or data-oriented gameplay. | Use DOTS only where complexity is justified; require data layout and performance rationale. | `.claude/agents/unity-dots-specialist.md` |
+| `unity-shader-specialist` | Shader Graph, HLSL, VFX Graph, URP/HDRP, post-processing, or visual effects. | Keep render-pipeline compatibility and performance budgets explicit. | `.claude/agents/unity-shader-specialist.md` |
+| `unity-addressables-specialist` | Addressables, asset loading/unloading, memory, content catalogs, remote content, or bundles. | Track lifetime, memory pressure, catalogs, and load-time risk. | `.claude/agents/unity-addressables-specialist.md` |
+| `unity-ui-specialist` | UI Toolkit, UGUI, data binding, runtime UI performance, input, or cross-platform adaptation. | Keep UI responsive, accessible, and independent from gameplay state ownership. | `.claude/agents/unity-ui-specialist.md` |
+
+## Unreal
+
+| Role | Use When | Codex Guidance | Source |
+| --- | --- | --- | --- |
+| `unreal-specialist` | Unreal architecture, Blueprint vs C++, GAS, Enhanced Input, Niagara, or engine subsystems. | Validate against pinned Unreal version and avoid unnecessary custom systems. | `.claude/agents/unreal-specialist.md` |
+| `ue-gas-specialist` | Gameplay Ability System abilities, effects, attributes, tags, ability tasks, or prediction. | Keep GAS architecture consistent and avoid ad hoc ability state outside GAS. | `.claude/agents/ue-gas-specialist.md` |
+| `ue-blueprint-specialist` | Blueprint architecture, Blueprint/C++ boundaries, maintainability, or optimization. | Prevent Blueprint spaghetti; define ownership and C++ boundaries clearly. | `.claude/agents/ue-blueprint-specialist.md` |
+| `ue-replication-specialist` | Unreal networking, replicated properties, RPCs, prediction, relevancy, net serialization, or bandwidth. | Keep server authority, responsiveness, and bandwidth constraints explicit. | `.claude/agents/ue-replication-specialist.md` |
+| `ue-umg-specialist` | UMG/CommonUI widgets, input routing, styling, binding, or UI optimization. | Follow Unreal UI best practices and support platform input paths. | `.claude/agents/ue-umg-specialist.md` |

--- a/.agents/roles/specialists.md
+++ b/.agents/roles/specialists.md
@@ -1,0 +1,30 @@
+# Specialist Roles
+
+Specialists handle focused implementation, content, QA, operations, and analysis
+work. Use them as targeted lenses when a request falls inside their domain.
+
+| Role | Use When | Codex Guidance | Source |
+| --- | --- | --- | --- |
+| `gameplay-programmer` | Implementing mechanics, player systems, combat, or interactive features. | Translate GDDs into data-driven, testable gameplay code and flag design deviations. | `.claude/agents/gameplay-programmer.md` |
+| `engine-programmer` | Core engine systems, rendering, physics, memory, resource loading, scene management, or hot paths. | Prioritize performance, stability, engine constraints, and clean framework boundaries. | `.claude/agents/engine-programmer.md` |
+| `ai-programmer` | Behavior trees, state machines, pathfinding, perception, decisions, NPC/enemy behavior, or AI debugging. | Make behavior debuggable, data-driven, performant, and testable. | `.claude/agents/ai-programmer.md` |
+| `network-programmer` | Multiplayer replication, lag compensation, matchmaking, protocols, bandwidth, or synchronization. | Prefer server-authoritative, versioned, secure, and bandwidth-aware designs. | `.claude/agents/network-programmer.md` |
+| `tools-programmer` | Editor extensions, authoring tools, debug utilities, pipeline automation, or workflow improvements. | Optimize developer workflow without coupling tools to runtime code unnecessarily. | `.claude/agents/tools-programmer.md` |
+| `ui-programmer` | Menus, HUDs, inventory screens, dialogue boxes, UI framework code, widgets, or binding. | UI displays state and emits events; it must not own gameplay state. Keep text localizable and input accessible. | `.claude/agents/ui-programmer.md` |
+| `systems-designer` | Combat formulas, progression curves, crafting, status effects, interaction matrices, or detailed subsystem rules. | Provide math, edge cases, tuning ranges, and acceptance criteria. | `.claude/agents/systems-designer.md` |
+| `level-designer` | Level layout, encounters, pacing, spatial puzzles, navigation, or area flow. | Connect layout to pillars, narrative purpose, landmarks, accessibility, and testable completion criteria. | `.claude/agents/level-designer.md` |
+| `economy-designer` | Resource economies, loot systems, sinks/faucets, progression curves, markets, or reward balance. | Analyze fairness, exploit paths, degeneracy, and non-predatory monetization. | `.claude/agents/economy-designer.md` |
+| `technical-artist` | Shaders, VFX, rendering optimization, art pipeline tools, or art-to-engine integration. | Balance visual quality with performance budgets and production constraints. | `.claude/agents/technical-artist.md` |
+| `sound-designer` | SFX specs, audio events, mix documentation, sound categories, or feedback sounds. | Define triggers, parameters, variation, mix groups, attenuation, and accessibility alternatives. | `.claude/agents/sound-designer.md` |
+| `writer` | Dialogue, lore entries, item text, ability descriptions, environmental text, or player-facing copy. | Preserve voice, string-key readiness, placeholder safety, and localization headroom. | `.claude/agents/writer.md` |
+| `world-builder` | Factions, cultures, history, geography, ecology, world rules, or lore consistency. | Track canon levels, contradictions, timelines, and environmental storytelling opportunities. | `.claude/agents/world-builder.md` |
+| `ux-designer` | User flows, interaction patterns, onboarding, accessibility, information architecture, or input design. | Define player intent, flow, states, edge cases, input paths, and accessibility requirements. | `.claude/agents/ux-designer.md` |
+| `prototyper` | Fast throwaway experiments, concept validation, vertical slices, or mechanic probes. | Isolate work under `prototypes/`, document hypothesis/results, and avoid production-code leakage. | `.claude/agents/prototyper.md` |
+| `performance-analyst` | Profiling, memory analysis, frame-time investigation, optimization strategy, or metrics tracking. | Require budgets, before/after evidence, and risk-ranked recommendations. | `.claude/agents/performance-analyst.md` |
+| `devops-engineer` | Build pipelines, CI/CD, branching strategy, deployment automation, or test infrastructure. | Prefer reproducible builds, clear scripts, safe release controls, and CI observability. | `.claude/agents/devops-engineer.md` |
+| `analytics-engineer` | Telemetry, event tracking, dashboards, A/B tests, funnels, or player behavior analysis. | Define events, schemas, success metrics, privacy constraints, and dashboard validation. | `.claude/agents/analytics-engineer.md` |
+| `security-engineer` | Cheat prevention, exploits, save security, networking security, authentication, or player data privacy. | Treat security as release risk; classify severity and avoid exposing secrets or unsafe patterns. | `.claude/agents/security-engineer.md` |
+| `qa-tester` | Test cases, bug reports, regression checklists, manual QA evidence, or execution documentation. | Produce reproducible steps, expected/actual results, evidence requirements, and clear verdicts. | `.claude/agents/qa-tester.md` |
+| `accessibility-specialist` | Remapping, text scaling, colorblind support, screen readers, subtitles, cognitive load, or accessibility audits. | Do not rely on a single sensory channel; identify blockers and alternatives. | `.claude/agents/accessibility-specialist.md` |
+| `live-ops-designer` | Seasons, events, battle passes, content cadence, retention, or live service economy. | Balance engagement with ethical monetization, content capacity, and analytics readiness. | `.claude/agents/live-ops-designer.md` |
+| `community-manager` | Patch notes, announcements, social posts, player feedback, community bug triage, or crisis communication. | Translate internal changes into clear player-facing language and sentiment-aware messaging. | `.claude/agents/community-manager.md` |

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -6,17 +6,20 @@ Keep the original MIT license and attribution intact.
 ## Repository Purpose
 
 This is a game-development workflow template for Codex. It adapts the original
-Claude Code assets into Codex-readable project instructions, skills, reference
-docs, and validation scripts.
+Claude Code assets into Codex-readable project instructions, skills, role
+references, docs, and validation scripts.
 
-The current source-of-truth assets are still under `.claude/` until each area is
-ported:
+The original upstream assets remain under `.claude/` for attribution and source
+material. Ported Codex-native assets live under `.agents/` and normal repo docs.
 
 - `.claude/agents/` contains the original studio role definitions.
 - `.claude/skills/` contains the original slash-command workflows.
 - `.claude/hooks/` contains the original validation and session scripts.
 - `.claude/rules/` contains the original path-scoped standards.
 - `.claude/docs/` contains workflow catalogs, templates, and technical guidance.
+- `.agents/skills/` contains Codex-native ports of the 72 original workflows.
+- `.agents/roles/` contains compact Codex role references for the 49 original
+  agent definitions.
 
 When porting, preserve the intent but remove Claude Code-specific assumptions.
 
@@ -28,6 +31,8 @@ When porting, preserve the intent but remove Claude Code-specific assumptions.
 - Convert named Claude subagents into Codex delegation guidance. Codex may use
   available subagent roles only when the user explicitly asks for delegation or
   parallel agent work.
+- Use `.agents/roles/` as the first stop for role-shaped analysis. Read
+  `.claude/agents/` only when full upstream detail is needed.
 - Convert `AskUserQuestion` steps into concise user questions. In default
   Codex operation, make reasonable assumptions unless a decision is genuinely
   blocking or risky.

--- a/README.md
+++ b/README.md
@@ -66,7 +66,7 @@ The result: you still make every decision, but now you have a team that asks the
 | Category | Count | Description |
 |----------|-------|-------------|
 | **Codex Skills** | 72 | Repo-local workflows under `.agents/skills/` for onboarding, design, architecture, stories, QA, release, and team coordination |
-| **Original Agent Roles** | 49 | Upstream role definitions across design, programming, art, audio, narrative, QA, and production, pending Codex role-reference conversion |
+| **Codex Role References** | 49 | Compact role references under `.agents/roles/`, mapped from the original agent definitions |
 | **Original Hooks** | 12 | Upstream validation scripts under `.claude/hooks/`; in Codex they are source material until explicit scripts or a plugin implement them |
 | **Original Rules** | 11 | Upstream path-scoped standards under `.claude/rules/`; Codex equivalents are being moved into AGENTS/docs guidance |
 | **Templates** | 39 | Document templates for GDDs, UX specs, ADRs, sprint plans, HUD design, accessibility, and more |
@@ -100,8 +100,8 @@ Tier 3 — Specialists (Sonnet/Haiku)
 
 ### Engine Specialists
 
-The template includes original role sets for all three major engines. Use them
-as engine-specific guidance while the Codex role library is being ported:
+The template includes role references for all three major engines. Use them as
+engine-specific guidance:
 
 | Engine | Lead Agent | Sub-Specialists |
 |--------|-----------|-----------------|
@@ -353,6 +353,7 @@ versions, and which files are safe to overwrite vs. which need a manual merge.
 AGENTS.md                           # Codex repository instructions
 .agents/
   skills/                           # 72 Codex workflow skills
+  roles/                            # 49 Codex role references
 CLAUDE.md                           # Upstream Claude Code configuration source
 .claude/
   settings.json                     # Upstream Claude Code settings source

--- a/docs/CODEX-PORTING.md
+++ b/docs/CODEX-PORTING.md
@@ -10,6 +10,8 @@ license and attribution.
 - Codex entry instructions exist in `AGENTS.md`.
 - Directory-scoped Codex instructions exist in `src/`, `design/`, and `docs/`.
 - 72 repo-local Codex skills exist in `.agents/skills/`.
+- Codex role references for all 49 original agent roles exist in
+  `.agents/roles/`.
 - Ported starter workflows: `cgs-start`, `cgs-help`,
   `cgs-project-stage-detect`, `cgs-adopt`, `cgs-setup-engine`,
   `cgs-brainstorm`, `cgs-map-systems`, `cgs-design-system`,
@@ -54,7 +56,7 @@ license and attribution.
 | `CLAUDE.md` | `AGENTS.md` |
 | `directory/CLAUDE.md` | `directory/AGENTS.md` |
 | `.claude/skills/*/SKILL.md` | Codex skills or workflow references |
-| `.claude/agents/*.md` | Role prompt references and delegation guidance |
+| `.claude/agents/*.md` | `.agents/roles/` compact Codex role references |
 | `.claude/hooks/*.sh` | Explicit validation scripts or plugin hooks |
 | `.claude/settings.json` | Instructions, scripts, and optional plugin manifest |
 | `/slash-command` usage | Natural-language requests or Codex skill triggers |
@@ -83,9 +85,9 @@ Port the smallest workflow set needed to use the project end-to-end:
 
 ### Phase 3: Role Library
 
-Convert the 49 original agent files into compact role references. Codex should
-use them to shape analysis and implementation, not as guaranteed named
-subagents.
+- Complete: the 49 original agent files are mapped in `.agents/roles/`.
+- Codex should use them to shape analysis and implementation, not as guaranteed
+  named subagents.
 
 ### Phase 4: Validation
 
@@ -114,6 +116,6 @@ team orchestration, release, and utility.
 ## Next Concrete Step
 
 The original 72 Claude Code skills now have repo-local Codex skill ports. Next,
-reconcile remaining README sections that still describe Claude Code as the
-primary interface, convert the 49 original agent files into compact Codex role
-references, and decide whether to package the Codex port as a plugin.
+port the original hooks into explicit Codex validation workflows, port
+path-scoped rules into Codex standards, and decide whether to package the Codex
+port as a plugin.


### PR DESCRIPTION
## Summary
- Add .agents/roles as compact Codex references for the 49 original Claude agent roles
- Split references into directors, department leads, general specialists, and engine specialists
- Update AGENTS, README, and CODEX-PORTING to use the new role library

## Validation
- 49 upstream agent files mapped to 49 role references
- comm diff confirms no missing role source mappings
- git diff --check
- bash -n .claude/hooks/*.sh
- python3 -m json.tool .claude/settings.json

Closes #4