### PR TITLE
Add explicit Codex validation workflow

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -97,8 +97,7 @@ engine is configured, validate documentation and shell scripts only.
 Suggested baseline checks:
 
 ```bash
-bash -n .claude/hooks/*.sh
-python3 -m json.tool .claude/settings.json
+bash tools/codex-validate.sh baseline
 ```
 
 ## Attribution

--- a/README.md
+++ b/README.md
@@ -426,9 +426,11 @@ Use them as explicit validation scripts or source material:
 Suggested baseline checks:
 
 ```bash
-bash -n .claude/hooks/*.sh
-python3 -m json.tool .claude/settings.json
+bash tools/codex-validate.sh baseline
 ```
+
+See [docs/CODEX-VALIDATION.md](docs/CODEX-VALIDATION.md) for the full hook
+migration table and validation modes.
 
 `settings.json` remains upstream Claude Code source material. Do not assume its
 permission rules apply to Codex.

--- a/docs/CODEX-PORTING.md
+++ b/docs/CODEX-PORTING.md
@@ -12,6 +12,8 @@ license and attribution.
 - 72 repo-local Codex skills exist in `.agents/skills/`.
 - Codex role references for all 49 original agent roles exist in
   `.agents/roles/`.
+- Explicit Codex validation commands exist in `tools/codex-validate.sh` and
+  `docs/CODEX-VALIDATION.md`.
 - Ported starter workflows: `cgs-start`, `cgs-help`,
   `cgs-project-stage-detect`, `cgs-adopt`, `cgs-setup-engine`,
   `cgs-brainstorm`, `cgs-map-systems`, `cgs-design-system`,
@@ -57,7 +59,7 @@ license and attribution.
 | `directory/CLAUDE.md` | `directory/AGENTS.md` |
 | `.claude/skills/*/SKILL.md` | Codex skills or workflow references |
 | `.claude/agents/*.md` | `.agents/roles/` compact Codex role references |
-| `.claude/hooks/*.sh` | Explicit validation scripts or plugin hooks |
+| `.claude/hooks/*.sh` | `tools/codex-validate.sh` and `docs/CODEX-VALIDATION.md` |
 | `.claude/settings.json` | Instructions, scripts, and optional plugin manifest |
 | `/slash-command` usage | Natural-language requests or Codex skill triggers |
 
@@ -91,13 +93,11 @@ Port the smallest workflow set needed to use the project end-to-end:
 
 ### Phase 4: Validation
 
-Convert hooks into explicit checks:
-
-- Session/project state check
-- Commit and push safety checks
-- Asset validation
-- Skill structure validation
-- Gap detection
+- Complete baseline: explicit checks exist for session/project state, staged
+  commit checks, asset validation, skill catalog validation, role catalog
+  validation, and gap detection.
+- Deferred automation: notification, compaction, push interception, and
+  subagent audit logging require plugin support.
 
 ### Phase 5: Full Catalog
 
@@ -116,6 +116,5 @@ team orchestration, release, and utility.
 ## Next Concrete Step
 
 The original 72 Claude Code skills now have repo-local Codex skill ports. Next,
-port the original hooks into explicit Codex validation workflows, port
-path-scoped rules into Codex standards, and decide whether to package the Codex
-port as a plugin.
+port path-scoped rules into Codex standards and decide whether deferred hook
+automation should be packaged as a Codex plugin.

--- a/docs/CODEX-VALIDATION.md
+++ b/docs/CODEX-VALIDATION.md
@@ -1,0 +1,59 @@
+# Codex Validation
+
+Codex does not automatically run the original Claude Code hooks in
+`.claude/hooks/`. This repository keeps those hooks as upstream source material
+and exposes explicit validation commands instead.
+
+## Quick Commands
+
+```bash
+bash tools/codex-validate.sh baseline
+bash tools/codex-validate.sh all
+bash tools/codex-validate.sh session
+bash tools/codex-validate.sh staged
+bash tools/codex-validate.sh assets
+bash tools/codex-validate.sh skills
+bash tools/codex-validate.sh roles
+```
+
+Use `baseline` before commits that touch documentation, skills, roles, hooks, or
+settings. Use `all` before release or template maintenance changes.
+
+## Hook Migration Decisions
+
+| Original Hook | Codex Equivalent | Decision |
+| --- | --- | --- |
+| `session-start.sh` | `bash tools/codex-validate.sh session` | Manual session-orientation check. |
+| `detect-gaps.sh` | `bash tools/codex-validate.sh session` | Manual gap-detection check. |
+| `validate-commit.sh` | `bash tools/codex-validate.sh staged` | Manual staged-change check before commit. |
+| `validate-push.sh` | Documentation reminder | Source material only until a plugin implements push interception. |
+| `validate-assets.sh` | `bash tools/codex-validate.sh assets` | Manual asset naming and JSON check. |
+| `validate-skill-change.sh` | `bash tools/codex-validate.sh skills` | Manual Codex skill catalog check. |
+| `pre-compact.sh` | Documentation/checklist | Source material; Codex compaction integration requires plugin support. |
+| `post-compact.sh` | Documentation/checklist | Source material; Codex compaction integration requires plugin support. |
+| `notify.sh` | Deferred plugin candidate | Source material; notification behavior is platform-specific. |
+| `session-stop.sh` | Documentation/checklist | Source material; automatic session-stop logging requires plugin support. |
+| `log-agent.sh` | Deferred plugin candidate | Source material; Codex subagent audit logging requires plugin support. |
+| `log-agent-stop.sh` | Deferred plugin candidate | Source material; Codex subagent audit logging requires plugin support. |
+
+## What Baseline Checks
+
+`baseline` verifies:
+
+- `.claude/hooks/*.sh` shell syntax.
+- `.claude/settings.json` JSON validity.
+- `.agents/skills/` contains 72 skills with required metadata.
+- `.agents/roles/` maps all 49 original role files.
+
+## What All Checks
+
+`all` runs `baseline`, then:
+
+- Asset naming warnings and JSON validity for `assets/data/*.json`.
+- Staged commit validation using the original `validate-commit.sh` logic.
+
+## Plugin Boundary
+
+These commands intentionally do not claim automatic hook execution. If this fork
+becomes a Codex plugin later, the plugin should call these explicit validation
+entrypoints rather than duplicating hook logic.

--- a/tools/codex-validate.sh
+++ b/tools/codex-validate.sh
@@ -1,0 +1,149 @@
+#!/usr/bin/env bash
+# Explicit Codex validation entrypoint for Codex Game Studios.
+# This does not install hooks. It runs checks manually from the terminal.
+
+set -u
+
+MODE="${1:-baseline}"
+FAILURES=0
+
+run_check() {
+  local label="$1"
+  shift
+  echo "==> $label"
+  if "$@"; then
+    echo "PASS: $label"
+  else
+    echo "FAIL: $label" >&2
+    FAILURES=$((FAILURES + 1))
+  fi
+  echo
+}
+
+python_json_tool() {
+  local file="$1"
+  for cmd in python3 python py; do
+    if command -v "$cmd" >/dev/null 2>&1; then
+      "$cmd" -m json.tool "$file" >/dev/null
+      return $?
+    fi
+  done
+  echo "No Python command found for JSON validation" >&2
+  return 1
+}
+
+validate_skill_catalog() {
+  local count
+  count=$(find .agents/skills -maxdepth 2 -name SKILL.md -print 2>/dev/null | wc -l | tr -d ' ')
+  if [ "$count" != "72" ]; then
+    echo "Expected 72 Codex skills, found $count" >&2
+    return 1
+  fi
+
+  if rg --files-without-match "short-description:" .agents/skills/*/SKILL.md >/tmp/cgs-missing-short-description.txt 2>/dev/null; then
+    echo "Skills missing metadata.short-description:" >&2
+    cat /tmp/cgs-missing-short-description.txt >&2
+    return 1
+  fi
+
+  local mismatch=0
+  for file in .agents/skills/*/SKILL.md; do
+    local dir name
+    dir=$(basename "$(dirname "$file")")
+    name=$(sed -n 's/^name: //p' "$file" | head -1)
+    if [ "$dir" != "$name" ]; then
+      echo "Skill folder/name mismatch: $dir -> $name" >&2
+      mismatch=1
+    fi
+  done
+
+  return "$mismatch"
+}
+
+validate_role_catalog() {
+  local source_count mapped_count missing
+  source_count=$(find .claude/agents -maxdepth 1 -type f -name '*.md' -print 2>/dev/null | wc -l | tr -d ' ')
+  mapped_count=$(rg -o '\.claude/agents/[a-z0-9-]+\.md' .agents/roles/*.md 2>/dev/null | sed 's/.*\.claude/.claude/' | sort -u | wc -l | tr -d ' ')
+
+  if [ "$source_count" != "$mapped_count" ]; then
+    echo "Expected $source_count role mappings, found $mapped_count" >&2
+    missing=$(comm -3 \
+      <(find .claude/agents -maxdepth 1 -type f -name '*.md' -printf '.claude/agents/%f\n' | sort) \
+      <(rg -o '\.claude/agents/[a-z0-9-]+\.md' .agents/roles/*.md | sed 's/.*\.claude/.claude/' | sort -u))
+    [ -n "$missing" ] && echo "$missing" >&2
+    return 1
+  fi
+}
+
+validate_assets() {
+  local failures=0
+  if [ -d assets ]; then
+    while IFS= read -r file; do
+      local base
+      base=$(basename "$file")
+      if echo "$base" | grep -qE '[A-Z[:space:]-]'; then
+        echo "Asset naming warning: $file should be lowercase_with_underscores" >&2
+      fi
+    done < <(find assets -type f 2>/dev/null)
+  fi
+
+  if [ -d assets/data ]; then
+    while IFS= read -r file; do
+      if ! python_json_tool "$file"; then
+        echo "Invalid JSON: $file" >&2
+        failures=$((failures + 1))
+      fi
+    done < <(find assets/data -type f -name '*.json' 2>/dev/null)
+  fi
+
+  return "$failures"
+}
+
+validate_staged_commit() {
+  printf '{"tool_input":{"command":"git commit"}}' | bash .claude/hooks/validate-commit.sh
+}
+
+run_baseline() {
+  run_check "Hook shell syntax" bash -n .claude/hooks/*.sh
+  run_check "Claude settings JSON" python_json_tool .claude/settings.json
+  run_check "Codex skill catalog" validate_skill_catalog
+  run_check "Codex role catalog" validate_role_catalog
+}
+
+case "$MODE" in
+  baseline)
+    run_baseline
+    ;;
+  all)
+    run_baseline
+    run_check "Asset validation" validate_assets
+    run_check "Staged commit validation" validate_staged_commit
+    ;;
+  session)
+    run_check "Session context" bash .claude/hooks/session-start.sh
+    run_check "Gap detection" bash .claude/hooks/detect-gaps.sh
+    ;;
+  staged)
+    run_check "Staged commit validation" validate_staged_commit
+    ;;
+  assets)
+    run_check "Asset validation" validate_assets
+    ;;
+  skills)
+    run_check "Codex skill catalog" validate_skill_catalog
+    ;;
+  roles)
+    run_check "Codex role catalog" validate_role_catalog
+    ;;
+  *)
+    echo "Usage: bash tools/codex-validate.sh [baseline|all|session|staged|assets|skills|roles]" >&2
+    exit 2
+    ;;
+esac
+
+if [ "$FAILURES" -gt 0 ]; then
+  echo "$FAILURES validation check(s) failed." >&2
+  exit 1
+fi
+
+echo "All requested validation checks passed."


### PR DESCRIPTION
## Summary
- Add tools/codex-validate.sh as the manual Codex validation entrypoint
- Document migration decisions for all 12 original Claude hooks in docs/CODEX-VALIDATION.md
- Update README, AGENTS, and CODEX-PORTING to point to explicit validation instead of automatic hook assumptions

## Validation
- bash -n tools/codex-validate.sh
- bash tools/codex-validate.sh baseline
- bash tools/codex-validate.sh all
- git diff --check

Closes #5