### PR TITLE
Add Codex path standards

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -88,6 +88,8 @@ file exists.
 - Add or update ADRs for new architecture decisions.
 - Keep generated or throwaway prototype code under `prototypes/`, not `src/`.
 - Check `docs/engine-reference/` before relying on engine APIs.
+- Read `docs/STANDARDS.md` and the nearest directory `AGENTS.md` before editing
+  path-sensitive code, assets, tests, prototypes, or design docs.
 
 ## Validation
 

--- a/README.md
+++ b/README.md
@@ -68,7 +68,7 @@ The result: you still make every decision, but now you have a team that asks the
 | **Codex Skills** | 72 | Repo-local workflows under `.agents/skills/` for onboarding, design, architecture, stories, QA, release, and team coordination |
 | **Codex Role References** | 49 | Compact role references under `.agents/roles/`, mapped from the original agent definitions |
 | **Original Hooks** | 12 | Upstream validation scripts under `.claude/hooks/`; in Codex they are source material until explicit scripts or a plugin implement them |
-| **Original Rules** | 11 | Upstream path-scoped standards under `.claude/rules/`; Codex equivalents are being moved into AGENTS/docs guidance |
+| **Codex Standards** | 11 | Path-scoped standards mapped into `docs/STANDARDS.md` and directory `AGENTS.md` files |
 | **Templates** | 39 | Document templates for GDDs, UX specs, ADRs, sprint plans, HUD design, accessibility, and more |
 
 ## Studio Roles
@@ -437,8 +437,8 @@ permission rules apply to Codex.
 
 ### Path-Scoped Rules
 
-The original path-scoped rules describe standards by file location. In Codex,
-they are guidance until each rule is moved into AGENTS/docs equivalents:
+The original path-scoped rules are mapped into
+[docs/STANDARDS.md](docs/STANDARDS.md) and directory `AGENTS.md` files:
 
 | Path | Enforces |
 |------|----------|

--- a/assets/AGENTS.md
+++ b/assets/AGENTS.md
@@ -1,0 +1,41 @@
+# Assets Directory Instructions
+
+Follow these standards when adding or editing art, audio, shader, VFX, and data
+assets.
+
+## Data Files
+
+For `assets/data/**`:
+
+- JSON files must be valid JSON.
+- Filenames use lowercase with underscores and the pattern
+  `[system]_[name].json`.
+- JSON keys use camelCase consistently.
+- Every data file needs a schema or corresponding design documentation.
+- Numeric values need rationale in comments, companion docs, or the relevant
+  GDD.
+- No orphaned entries; data should be referenced by code or another data file.
+- Version data files when making breaking schema changes.
+- Optional fields need sensible defaults.
+
+## Shaders
+
+For `assets/shaders/**`:
+
+- Use descriptive names with shader type or engine convention, such as
+  `spatial_env_water.gdshader`, `SG_Env_Water`, or `M_Env_Water`.
+- Name uniforms/parameters clearly and group related settings.
+- Comment non-obvious calculations and document purpose at the top.
+- Avoid magic numbers; use named constants or documented uniform values.
+- Document target platform, render pipeline, and complexity budget.
+- Minimize fragment texture samples, dynamic branching, texture reads in loops,
+  and shader variants.
+- Provide lower-quality fallbacks when required by target hardware.
+
+## Validation
+
+Run:
+
+```bash
+bash tools/codex-validate.sh assets
+```

--- a/design/AGENTS.md
+++ b/design/AGENTS.md
@@ -36,3 +36,19 @@ additions that do not need a full GDD.
 
 Before passing UX work to implementation, check alignment with the relevant GDDs
 and accessibility requirements.
+
+## Narrative Docs
+
+For `design/narrative/**`:
+
+- Cross-reference new lore against existing lore for contradictions.
+- Every lore entry needs a canon level: Established, Provisional, or Under
+  Review.
+- Dialogue must match the relevant character voice profile.
+- World rules must state what is possible and impossible.
+- Mysteries need documented true answers even if players never learn them.
+- Faction motivations, relationships, and power structures must be internally
+  logical.
+- Player-facing text must be localization-ready with named placeholders.
+- Dialogue lines should stay under 120 characters unless the UI spec allows
+  longer text.

--- a/docs/CODEX-PORTING.md
+++ b/docs/CODEX-PORTING.md
@@ -14,6 +14,8 @@ license and attribution.
   `.agents/roles/`.
 - Explicit Codex validation commands exist in `tools/codex-validate.sh` and
   `docs/CODEX-VALIDATION.md`.
+- Codex standards for all 11 original path-scoped rules exist in
+  `docs/STANDARDS.md` and directory `AGENTS.md` files.
 - Ported starter workflows: `cgs-start`, `cgs-help`,
   `cgs-project-stage-detect`, `cgs-adopt`, `cgs-setup-engine`,
   `cgs-brainstorm`, `cgs-map-systems`, `cgs-design-system`,
@@ -60,6 +62,7 @@ license and attribution.
 | `.claude/skills/*/SKILL.md` | Codex skills or workflow references |
 | `.claude/agents/*.md` | `.agents/roles/` compact Codex role references |
 | `.claude/hooks/*.sh` | `tools/codex-validate.sh` and `docs/CODEX-VALIDATION.md` |
+| `.claude/rules/*.md` | `docs/STANDARDS.md` and directory `AGENTS.md` files |
 | `.claude/settings.json` | Instructions, scripts, and optional plugin manifest |
 | `/slash-command` usage | Natural-language requests or Codex skill triggers |
 
@@ -116,5 +119,5 @@ team orchestration, release, and utility.
 ## Next Concrete Step
 
 The original 72 Claude Code skills now have repo-local Codex skill ports. Next,
-port path-scoped rules into Codex standards and decide whether deferred hook
-automation should be packaged as a Codex plugin.
+decide whether deferred hook automation and distribution should be packaged as a
+Codex plugin.

--- a/docs/CODEX-VALIDATION.md
+++ b/docs/CODEX-VALIDATION.md
@@ -14,6 +14,7 @@ bash tools/codex-validate.sh staged
 bash tools/codex-validate.sh assets
 bash tools/codex-validate.sh skills
 bash tools/codex-validate.sh roles
+bash tools/codex-validate.sh standards
 ```
 
 Use `baseline` before commits that touch documentation, skills, roles, hooks, or
@@ -44,6 +45,7 @@ settings. Use `all` before release or template maintenance changes.
 - `.claude/settings.json` JSON validity.
 - `.agents/skills/` contains 72 skills with required metadata.
 - `.agents/roles/` maps all 49 original role files.
+- `docs/STANDARDS.md` maps all 11 original path-scoped rule files.
 
 ## What All Checks
 

--- a/docs/STANDARDS.md
+++ b/docs/STANDARDS.md
@@ -1,0 +1,32 @@
+# Codex Standards
+
+These standards are the Codex-readable equivalent of the original
+`.claude/rules/` path-scoped rules. The original files remain as upstream source
+material; use this document and directory `AGENTS.md` files during Codex work.
+
+## Source Mapping
+
+| Original Rule | Codex Location | Status |
+| --- | --- | --- |
+| `.claude/rules/gameplay-code.md` | `src/AGENTS.md` | Ported |
+| `.claude/rules/engine-code.md` | `src/AGENTS.md` | Ported |
+| `.claude/rules/ai-code.md` | `src/AGENTS.md` | Ported |
+| `.claude/rules/network-code.md` | `src/AGENTS.md` | Ported |
+| `.claude/rules/ui-code.md` | `src/AGENTS.md` | Ported |
+| `.claude/rules/design-docs.md` | `design/AGENTS.md` | Ported |
+| `.claude/rules/narrative.md` | `design/AGENTS.md` | Ported |
+| `.claude/rules/data-files.md` | `assets/AGENTS.md` | Ported |
+| `.claude/rules/shader-code.md` | `assets/AGENTS.md` | Ported |
+| `.claude/rules/test-standards.md` | `tests/AGENTS.md` | Ported |
+| `.claude/rules/prototype-code.md` | `prototypes/AGENTS.md` | Ported |
+
+## Cross-Cutting Rules
+
+- Keep gameplay behavior traceable to GDDs, ADRs, or quick specs.
+- Keep balance and tuning values data-driven unless working in `prototypes/`.
+- Check `docs/engine-reference/` before relying on engine APIs.
+- Ask before changing major game direction, architecture, or multi-file workflow
+  structure.
+- Add tests or manual evidence for behavior changes.
+- Do not claim automatic Claude Code rule enforcement in Codex; these standards
+  are instructions and review criteria.

--- a/prototypes/AGENTS.md
+++ b/prototypes/AGENTS.md
@@ -1,0 +1,28 @@
+# Prototypes Directory Instructions
+
+Prototype standards are intentionally relaxed. The goal is learning quickly, not
+shipping production-quality code.
+
+## Allowed In Prototypes
+
+- Hardcoded values.
+- Minimal doc comments.
+- Simple architecture.
+- Singletons or global state.
+- Copy-pasted code.
+- Debug output.
+- Placeholder art, audio, and data.
+
+## Still Required
+
+- Each prototype lives in `prototypes/[name]/`.
+- Each prototype has a `README.md` with hypothesis, how to run, status, and
+  findings.
+- Prototype code must not be imported by production code.
+- Prototypes must not modify files outside `prototypes/`.
+- Prototypes must not be deployed or shipped.
+
+## Promotion Rule
+
+When a prototype succeeds, rewrite the production feature to normal standards.
+Do not gradually clean prototype code into production code.

--- a/src/AGENTS.md
+++ b/src/AGENTS.md
@@ -16,6 +16,50 @@ for recently changed Godot, Unity, or Unreal APIs.
 - Keep networking server-authoritative when multiplayer is present.
 - Add tests for formulas, edge cases, and gameplay rules.
 
+## Path-Specific Standards
+
+### `src/gameplay/**`
+
+- Keep all gameplay values in external config/data files.
+- Use delta time for all time-dependent calculations.
+- Do not reference UI code directly; use events/signals.
+- State machines need explicit transition tables and documented states.
+- Document which GDD each feature implements.
+
+### `src/core/**` and engine/framework code
+
+- Avoid allocations in hot paths; pre-allocate, pool, and reuse.
+- Engine/framework code must not depend on gameplay code.
+- Profile before and after optimizations and record measurements.
+- Public interface changes need migration guidance.
+- Resource cleanup must be deterministic where the engine/language supports it.
+
+### `src/ai/**`
+
+- Keep AI parameters tunable from data.
+- Make AI debuggable with state, path, perception, or decision visualization.
+- Prefer utility AI or behavior trees over hardcoded if/else chains for complex
+  behavior.
+- Log state-machine transitions for debugging.
+- Keep per-frame AI work within the documented budget when one exists.
+
+### `src/networking/**`
+
+- Server is authoritative for gameplay-critical state.
+- Version all network messages.
+- Validate packet sizes, field ranges, and client-provided values.
+- Document replication strategy, frequency, interpolation, and bandwidth budget.
+- Handle disconnects, reconnects, and host migration where applicable.
+
+### `src/ui/**`
+
+- UI displays state and emits commands/events; it must not own game state.
+- All player-facing text goes through localization.
+- Support keyboard/mouse and gamepad for interactive elements.
+- Animations must be skippable and respect motion/accessibility preferences.
+- Route UI sounds through the audio event system.
+- Test minimum and maximum supported resolutions.
+
 ## Architecture
 
 Every new core system should map back to a GDD and, when it changes technical

--- a/tests/AGENTS.md
+++ b/tests/AGENTS.md
@@ -1,0 +1,32 @@
+# Tests Directory Instructions
+
+Follow these standards for automated and manual test assets.
+
+## Automated Tests
+
+- Use descriptive names: `test_[system]_[scenario]_[expected_result]`.
+- Keep arrange, act, and assert phases clear.
+- Unit tests must not depend on external state such as filesystem, network, or
+  database unless that dependency is explicitly mocked.
+- Integration tests must clean up after themselves.
+- Performance tests must specify thresholds and fail when thresholds are
+  exceeded.
+- Keep test data local to the test or in dedicated fixtures; avoid shared
+  mutable state.
+- Every bug fix should add a regression test or documented manual evidence that
+  would catch the original issue.
+
+## Manual Evidence
+
+- Store QA evidence under `production/qa/` unless a specific workflow says
+  otherwise.
+- Include build/version, date, tester, steps, expected result, actual result,
+  and artifacts when relevant.
+
+## Validation
+
+Run the engine-specific test command when configured. For template-level checks:
+
+```bash
+bash tools/codex-validate.sh baseline
+```

--- a/tools/codex-validate.sh
+++ b/tools/codex-validate.sh
@@ -75,6 +75,21 @@ validate_role_catalog() {
   fi
 }
 
+validate_standard_catalog() {
+  local source_count mapped_count missing
+  source_count=$(find .claude/rules -maxdepth 1 -type f -name '*.md' -print 2>/dev/null | wc -l | tr -d ' ')
+  mapped_count=$(rg -o '\.claude/rules/[a-z0-9-]+\.md' docs/STANDARDS.md 2>/dev/null | sort -u | wc -l | tr -d ' ')
+
+  if [ "$source_count" != "$mapped_count" ]; then
+    echo "Expected $source_count rule mappings, found $mapped_count" >&2
+    missing=$(comm -3 \
+      <(find .claude/rules -maxdepth 1 -type f -name '*.md' -printf '.claude/rules/%f\n' | sort) \
+      <(rg -o '\.claude/rules/[a-z0-9-]+\.md' docs/STANDARDS.md | sort -u))
+    [ -n "$missing" ] && echo "$missing" >&2
+    return 1
+  fi
+}
+
 validate_assets() {
   local failures=0
   if [ -d assets ]; then
@@ -108,6 +123,7 @@ run_baseline() {
   run_check "Claude settings JSON" python_json_tool .claude/settings.json
   run_check "Codex skill catalog" validate_skill_catalog
   run_check "Codex role catalog" validate_role_catalog
+  run_check "Codex standards catalog" validate_standard_catalog
 }
 
 case "$MODE" in
@@ -135,8 +151,11 @@ case "$MODE" in
   roles)
     run_check "Codex role catalog" validate_role_catalog
     ;;
+  standards)
+    run_check "Codex standards catalog" validate_standard_catalog
+    ;;
   *)
-    echo "Usage: bash tools/codex-validate.sh [baseline|all|session|staged|assets|skills|roles]" >&2
+    echo "Usage: bash tools/codex-validate.sh [baseline|all|session|staged|assets|skills|roles|standards]" >&2
     exit 2
     ;;
 esac


### PR DESCRIPTION
## Summary
- Add docs/STANDARDS.md mapping all 11 original .claude/rules files to Codex-readable standards
- Add assets/tests/prototypes AGENTS instructions and expand src/design path-specific guidance
- Extend tools/codex-validate.sh with standards catalog validation

## Validation
- bash -n tools/codex-validate.sh
- bash tools/codex-validate.sh baseline
- bash tools/codex-validate.sh standards
- rule source mapping diff check: no missing mappings
- git diff --check

Closes #6