### PR TITLE
Record Codex packaging strategy

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,8 +28,8 @@
 
 > **Porting status:** The original 72 workflow skills now have repo-local Codex
 > ports under `.agents/skills/`. Claude Code assets remain available under
-> `.claude/` as upstream source material while agents, hooks, and rules continue
-> to be adapted for Codex.
+> `.claude/` as upstream source material; skills, role references, validation,
+> and path-scoped standards now have Codex-readable equivalents.
 
 ## Why This Exists
 
@@ -67,7 +67,7 @@ The result: you still make every decision, but now you have a team that asks the
 |----------|-------|-------------|
 | **Codex Skills** | 72 | Repo-local workflows under `.agents/skills/` for onboarding, design, architecture, stories, QA, release, and team coordination |
 | **Codex Role References** | 49 | Compact role references under `.agents/roles/`, mapped from the original agent definitions |
-| **Original Hooks** | 12 | Upstream validation scripts under `.claude/hooks/`; in Codex they are source material until explicit scripts or a plugin implement them |
+| **Codex Validation** | 12 | Original hooks mapped to explicit validation commands in `tools/codex-validate.sh` and `docs/CODEX-VALIDATION.md` |
 | **Codex Standards** | 11 | Path-scoped standards mapped into `docs/STANDARDS.md` and directory `AGENTS.md` files |
 | **Templates** | 39 | Document templates for GDDs, UX specs, ADRs, sprint plans, HUD design, accessibility, and more |
 
@@ -309,6 +309,16 @@ Coordinate narrative work for the boss intro scene.
 The original Claude Code workflows remain available under `.claude/` as source
 material and attribution history. The active Codex workflow ports are under
 `.agents/skills/`.
+
+## Distribution
+
+This fork is distributed as a repository template first. Clone or fork it, then
+run Codex from the repository root so it can read `AGENTS.md`, `.agents/skills/`,
+`.agents/roles/`, and the directory-specific instructions.
+
+Codex plugin packaging is intentionally deferred. See
+[ADR-0001](docs/architecture/adr-0001-codex-plugin-packaging.md) for the
+decision and revisit criteria.
 
 ## Getting Started
 

--- a/docs/CODEX-PORTING.md
+++ b/docs/CODEX-PORTING.md
@@ -16,6 +16,8 @@ license and attribution.
   `docs/CODEX-VALIDATION.md`.
 - Codex standards for all 11 original path-scoped rules exist in
   `docs/STANDARDS.md` and directory `AGENTS.md` files.
+- Codex plugin packaging is intentionally deferred by
+  `docs/architecture/adr-0001-codex-plugin-packaging.md`.
 - Ported starter workflows: `cgs-start`, `cgs-help`,
   `cgs-project-stage-detect`, `cgs-adopt`, `cgs-setup-engine`,
   `cgs-brainstorm`, `cgs-map-systems`, `cgs-design-system`,
@@ -63,7 +65,7 @@ license and attribution.
 | `.claude/agents/*.md` | `.agents/roles/` compact Codex role references |
 | `.claude/hooks/*.sh` | `tools/codex-validate.sh` and `docs/CODEX-VALIDATION.md` |
 | `.claude/rules/*.md` | `docs/STANDARDS.md` and directory `AGENTS.md` files |
-| `.claude/settings.json` | Instructions, scripts, and optional plugin manifest |
+| `.claude/settings.json` | Instructions, scripts, and deferred plugin reference |
 | `/slash-command` usage | Natural-language requests or Codex skill triggers |
 
 ## Recommended Migration Phases
@@ -73,7 +75,8 @@ license and attribution.
 - Add `AGENTS.md` and directory-scoped `AGENTS.md` files.
 - Add this porting plan.
 - Add README attribution and explain the fork status.
-- Decide whether to package the port as a Codex plugin.
+- Decide whether to package the port as a Codex plugin. Decision recorded in
+  `docs/architecture/adr-0001-codex-plugin-packaging.md`.
 
 ### Phase 2: Core Workflows
 
@@ -118,6 +121,7 @@ team orchestration, release, and utility.
 
 ## Next Concrete Step
 
-The original 72 Claude Code skills now have repo-local Codex skill ports. Next,
-decide whether deferred hook automation and distribution should be packaged as a
-Codex plugin.
+The core Codex port is complete at the template level: skills, role references,
+validation, standards, README positioning, and packaging decision are in place.
+Future work should be tracked as feature-specific improvements rather than
+foundational migration tasks.

--- a/docs/architecture/adr-0001-codex-plugin-packaging.md
+++ b/docs/architecture/adr-0001-codex-plugin-packaging.md
@@ -1,0 +1,57 @@
+# ADR-0001: Codex Plugin Packaging Strategy
+
+## Status
+
+Accepted
+
+## Context
+
+Codex Game Studios is an unofficial Codex-oriented fork of Claude Code Game
+Studios. The fork now has:
+
+- 72 repo-local Codex skills in `.agents/skills/`.
+- 49 Codex role references in `.agents/roles/`.
+- Explicit validation workflows in `tools/codex-validate.sh`.
+- Codex-readable standards in `docs/STANDARDS.md` and directory `AGENTS.md`
+  files.
+
+The remaining packaging question is whether the project should ship as a Codex
+plugin or remain a repository template.
+
+## Decision
+
+Use a repository-local template as the primary distribution path. Defer Codex
+plugin packaging.
+
+## Rationale
+
+- The workflow catalog is project-specific and benefits from living beside game
+  docs, production records, assets, tests, and engine references.
+- `.agents/skills/`, `.agents/roles/`, `AGENTS.md`, and directory `AGENTS.md`
+  files already provide Codex-readable behavior without a plugin install step.
+- The original hook behavior has been converted into explicit validation
+  commands. The only strong plugin use case is future automation for
+  notifications, compaction recovery, push interception, and subagent audit
+  logging.
+- Deferring plugin packaging avoids duplicating skill and role docs in two
+  distribution formats before the template has stabilized.
+
+## Consequences
+
+- Users consume this project by cloning, forking, or using it as a template.
+- Plugin-specific metadata is intentionally not added yet.
+- Future plugin work should call the explicit validation entrypoints instead of
+  duplicating hook logic.
+- If plugin packaging becomes necessary, create a new issue with a concrete
+  install/update workflow and automation scope.
+
+## Revisit Criteria
+
+Reconsider plugin packaging when one of these becomes true:
+
+- Codex needs automatic hook-like behavior for this project.
+- Users need to install the studio workflows into many existing repositories
+  without adopting this template structure.
+- The skill/role/standards catalog stabilizes enough to package without frequent
+  repo-template changes.
+- A documented plugin distribution and update workflow is required by users.


### PR DESCRIPTION
## Summary
- Record ADR-0001: repository-local template is the primary distribution path
- Defer Codex plugin packaging until there is a concrete automation/install need
- Update README and CODEX-PORTING with the packaging decision and current port status

## Validation
- bash tools/codex-validate.sh baseline
- git diff --check

Closes #7